### PR TITLE
fix: adapt the API change in `textrepo` (0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 Nothing to record here.
 
+## [0.1.2] - 2020-10-15
+### Fixed
+- Adapt the API change in `textrepo` (0.4.0).
+
 ## [0.1.0] - 2020-10-12
 ### Added
 - Import files those are part of `examples` in the `textrepo` gem.

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ gemspec
 gem "rake", "~> 12.0"
 gem "minitest", "~> 5.0"
 
-gem 'textrepo', github: 'mnbi/textrepo', branch: 'main'
+gem 'textrepo', "~> 0.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,8 @@
-GIT
-  remote: https://github.com/mnbi/textrepo.git
-  revision: 0f48f81bd2402f10f21903dd3849c1e56158545e
-  branch: main
-  specs:
-    textrepo (0.3.0)
-
 PATH
   remote: .
   specs:
-    rbnotes (0.1.1)
-      textrepo
+    rbnotes (0.1.2)
+      textrepo (~> 0.4)
       unicode-display_width (~> 1.7)
 
 GEM
@@ -17,6 +10,7 @@ GEM
   specs:
     minitest (5.14.2)
     rake (12.3.3)
+    textrepo (0.4.0)
     unicode-display_width (1.7.0)
 
 PLATFORMS
@@ -26,7 +20,7 @@ DEPENDENCIES
   minitest (~> 5.0)
   rake (~> 12.0)
   rbnotes!
-  textrepo!
+  textrepo (~> 0.4)
 
 BUNDLED WITH
    2.1.4

--- a/lib/rbnotes/commands/list.rb
+++ b/lib/rbnotes/commands/list.rb
@@ -8,7 +8,7 @@ module Rbnotes
       max = (args.shift || @row - 3).to_i
 
       @repo = Textrepo.init(conf)
-      notes = @repo.notes.sort{|a, b| b <=> a}
+      notes = @repo.entries.sort{|a, b| b <=> a}
       notes[0, max].each { |timestamp_str|
         puts make_headline(timestamp_str)
       }

--- a/lib/rbnotes/version.rb
+++ b/lib/rbnotes/version.rb
@@ -1,4 +1,4 @@
 module Rbnotes
-  VERSION = "0.1.1"
-  RELEASE = '2020-10-13'
+  VERSION = "0.1.2"
+  RELEASE = '2020-10-15'
 end

--- a/rbnotes.gemspec
+++ b/rbnotes.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "textrepo"
+  spec.add_dependency "textrepo", "~> 0.4"
   spec.add_dependency "unicode-display_width", "~> 1.7"
 end


### PR DESCRIPTION
- modify the code of `list` command to adapt the API change
- update Gemfile and gemspec to specify version of `textrepo`

This commit will fix #9.