### PR TITLE
fix: add help text for the `conf` command

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rbnotes (0.1.2)
+    rbnotes (0.1.3)
       textrepo (~> 0.4)
       unicode-display_width (~> 1.7)
 
@@ -10,7 +10,7 @@ GEM
   specs:
     minitest (5.14.2)
     rake (12.3.3)
-    textrepo (0.4.0)
+    textrepo (0.4.1)
     unicode-display_width (1.7.0)
 
 PLATFORMS

--- a/lib/rbnotes/commands.rb
+++ b/lib/rbnotes/commands.rb
@@ -22,6 +22,7 @@ command:
     list NUM        : list NUM notes
     show STAMP      : show the note specified with STAMP
 
+    conf            : print the current configuraitons
     repo            : print the repository path
     stamp  TIME_STR : convert TIME_STR into a timestamp
     time   STAMP    : convert STAMP into a time string

--- a/lib/rbnotes/version.rb
+++ b/lib/rbnotes/version.rb
@@ -1,4 +1,4 @@
 module Rbnotes
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
   RELEASE = '2020-10-15'
 end

--- a/test/rbnotes_commands_test.rb
+++ b/test/rbnotes_commands_test.rb
@@ -16,6 +16,24 @@ class RbnotesCommandsTest < Minitest::Test
     }
   end
 
+  # Builtins::Help
+  def test_that_builtin_help_message_contains_abou_all_of_builtins
+    result = execute(:help, [], CONF_RW)
+    builtins = Rbnotes::Commands::Builtins.constants.map { |sym|
+      obj = Rbnotes::Commands::Builtins.const_get(sym)
+      if obj.instance_of?(Class) &&
+         obj.superclass == Rbnotes::Commands::Command
+        obj.to_s.split("::")[-1]
+      else
+        nil
+      end
+    }.compact
+
+    builtins.each { |sym|
+      assert result.include?(sym.to_s.downcase)
+    }
+  end
+
   # Builtins::Repo
   def test_that_builtin_repo_returns_path_of_the_repository
     expected = repo_path(CONF_RW)


### PR DESCRIPTION
- modify help text which the `help` command displays
- add a test to verify the help text includes all of the builtin
  command name

This commit will fix #11.