### PR TITLE
feat: read an argument from the standard input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 Nothing to record here.
 
+## [0.3.0] - 2020-10-29
+### Added
+- Add feature to read argument from the standard input. (#27)
+
 ## [0.2.2] - 2020-10-27
-###
+### Added
 - Add feature to accept a timestamp pattern in `list` command. (#22)
 
 ## [0.2.1] - 2020-10-25

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rbnotes (0.2.2)
+    rbnotes (0.3.0)
       textrepo (~> 0.4)
       unicode-display_width (~> 1.7)
 
@@ -10,7 +10,7 @@ GEM
   specs:
     minitest (5.14.2)
     rake (13.0.1)
-    textrepo (0.4.3)
+    textrepo (0.4.4)
     unicode-display_width (1.7.0)
 
 PLATFORMS

--- a/exe/rbnotes
+++ b/exe/rbnotes
@@ -17,7 +17,7 @@ app = App.new
 begin
   app.run(ARGV)
 rescue MissingArgumentError, MissingTimestampError,
-       NoEditorError, ProgramAbortError => e
+       InvalidTimestampStringError, NoEditorError, ProgramAbortError => e
   puts e.message
   exit 1
 end

--- a/lib/rbnotes/commands/delete.rb
+++ b/lib/rbnotes/commands/delete.rb
@@ -14,21 +14,17 @@
 module Rbnotes
   class Commands::Delete < Commands::Command
     def execute(args, conf)
-      stamp_str = args.shift
-      unless stamp_str.nil?
-        repo = Textrepo.init(conf)
-        begin
-          stamp = Textrepo::Timestamp.parse_s(stamp_str)
-          repo.delete(stamp)
-        rescue Textrepo::MissingTimestampError => e
-          puts e.message
-        rescue StandardError => e
-          puts e.message
-        else
-          puts "Delete [%s]" % stamp.to_s
-        end
+      stamp = Rbnotes::Utils.read_timestamp(args)
+
+      repo = Textrepo.init(conf)
+      begin
+        repo.delete(stamp)
+      rescue Textrepo::MissingTimestampError => e
+        puts e.message
+      rescue StandardError => e
+        puts e.message
       else
-        super
+        puts "Delete [%s]" % stamp.to_s
       end
     end
   end

--- a/lib/rbnotes/commands/import.rb
+++ b/lib/rbnotes/commands/import.rb
@@ -29,7 +29,7 @@ module Rbnotes
               puts "The note [%s] in the repository exactly matches" \
                    " the specified file." % stamp
               puts "It seems there is no need to import the file [%s]." % file
-              exit              # normal end
+              break
             else
               puts "The text in the repository does not match the" \
                    " specified file."
@@ -40,8 +40,8 @@ module Rbnotes
             end
           rescue Textrepo::EmptyTextError => _
             puts "... aborted."
-            puts "The specified file is empyt."
-            exit 1              # error
+            puts "The specified file is empty."
+            break
           end
         end
         if count > 999

--- a/lib/rbnotes/commands/list.rb
+++ b/lib/rbnotes/commands/list.rb
@@ -54,11 +54,11 @@ module Rbnotes
     # Makes a headline with the timestamp and subject of the notes, it
     # looks like as follows:
     #
-    #   |<------------------ console column size --------------------->|
-    #   +-- timestamp ---+  +--- subject (the 1st line of each note) --+
-    #   |                |  |                                          |
-    #   20101010001000_123: # I love Macintosh.                        [EOL]
-    #   20100909090909_999: # This is very very long long loooong subje[EOL]
+    #   |<------------------ console column size ------------------->|
+    #   +-- timestamp ---+  +-  subject (the 1st line of each note) -+
+    #   |                |  |                                        |
+    #   20101010001000_123: I love Macintosh.                        [EOL]
+    #   20100909090909_999: This is very very long long loooong subje[EOL]
     #                     ++
     #                      ^--- delimiter (2 characters)
     #
@@ -69,9 +69,7 @@ module Rbnotes
       delimiter = ": "
       subject_width = column - TIMESTAMP_STR_MAX_WIDTH - delimiter.size - 1
 
-      subject = @repo.read(timestamp)[0]
-      prefix = '# '
-      subject = prefix + subject.lstrip if subject[0, 2] != prefix
+      subject = remove_heading_markup(@repo.read(timestamp)[0])
 
       ts_part = "#{timestamp.to_s}    "[0..(TIMESTAMP_STR_MAX_WIDTH - 1)] 
       sj_part = truncate_str(subject, subject_width)
@@ -88,6 +86,10 @@ module Rbnotes
         result << c
       }
       result
+    end
+
+    def remove_heading_markup(str)
+      str.sub(/^#+ +/, '')
     end
 
     # :startdoc:

--- a/lib/rbnotes/commands/show.rb
+++ b/lib/rbnotes/commands/show.rb
@@ -1,24 +1,20 @@
 module Rbnotes
   class Commands::Show < Commands::Command
     def execute(args, conf)
-      stamp_str = args.shift
-      unless stamp_str.nil?
-        repo = Textrepo.init(conf)
-        stamp = Textrepo::Timestamp.parse_s(stamp_str)
-        content = repo.read(stamp)
+      stamp = Rbnotes::Utils.read_timestamp(args)
 
-        pager = conf[:pager]
-        unless pager.nil?
-          require 'open3'
-          Open3.pipeline_w(pager) { |stdin|
-            stdin.puts content
-            stdin.close
-          }
-        else
-          puts content
-        end
+      repo = Textrepo.init(conf)
+      content = repo.read(stamp)
+
+      pager = conf[:pager]
+      unless pager.nil?
+        require 'open3'
+        Open3.pipeline_w(pager) { |stdin|
+          stdin.puts content
+          stdin.close
+        }
       else
-        super
+        puts content
       end
     end
   end

--- a/lib/rbnotes/commands/update.rb
+++ b/lib/rbnotes/commands/update.rb
@@ -19,7 +19,7 @@ module Rbnotes::Commands
   # as add command.
   #
   # If none of editors is available, the command fails.
-  #
+
   class Update < Command
     include ::Rbnotes::Utils
 
@@ -30,19 +30,10 @@ module Rbnotes::Commands
     #
     # :call-seq:
     #     "20201020112233" -> "20201021123400"
-    #
+
     def execute(args, conf)
-      raise Rbnotes::MissingArgumentError, args if args.size < 1
-
-      target_stamp = nil
-      begin
-        target_stamp = Textrepo::Timestamp.parse_s(args.shift)
-      rescue ArgumentError => e
-        raise Rbnotes::MissingArgumentError, args
-      end
-
+      target_stamp = Rbnotes::Utils.read_timestamp(args)
       editor = find_editor(conf[:editor])
-
       repo = Textrepo.init(conf)
 
       text = nil

--- a/lib/rbnotes/error.rb
+++ b/lib/rbnotes/error.rb
@@ -1,13 +1,15 @@
 module Rbnotes
   ##
   # A base class for each error class of rbnotes.
-  #
+
   class Error < StandardError; end
 
   # :stopdoc:
+
   module ErrMsg
     MISSING_ARGUMENT  = "missing argument: %s"
     MISSING_TIMESTAMP = "missing timestamp: %s"
+    INVALID_TIMESTAMP_STRING = "invalid string as timestamp: %s"
     NO_EDITOR         = "No editor is available: %s"
     PROGRAM_ABORT     = "External program was aborted: %s"
   end
@@ -16,7 +18,7 @@ module Rbnotes
 
   ##
   # An error raised if an essential argument was missing.
-  #
+
   class MissingArgumentError < Error
     def initialize(args)
       super(ErrMsg::MISSING_ARGUMENT % args.to_s)
@@ -26,7 +28,7 @@ module Rbnotes
   ##
   # An error raised if a given timestamp was not found in the
   # repository.
-  #
+
   class MissingTimestampError < Error
     def initialize(timestamp)
       super(ErrMsg::MISSING_TIMESTAMP % timestamp)
@@ -34,9 +36,19 @@ module Rbnotes
   end
 
   ##
+  # An error raised if an argument is invalid to convert a
+  # Textrepo::Timestamp object.
+
+  class InvalidTimestampStringError < Error
+    def initialize(str)
+      super(ErrMsg::INVALID_TIMESTAMP_STRING % str)
+    end
+  end
+
+  ##
   # An error raised if no external editor is available to edit a note,
   # even "nano" or "vi".
-  #
+
   class NoEditorError < Error
     def initialize(names)
       super(ErrMsg::NO_EDITOR % names.to_s)
@@ -46,6 +58,7 @@ module Rbnotes
   ##
   # An error raised when a external program such an editor was aborted
   # during its execution.
+
   class ProgramAbortError < Error
     def initialize(cmdline)
       super(ErrMsg::PROGRAM_ABORT % cmdline.join(" "))

--- a/lib/rbnotes/utils.rb
+++ b/lib/rbnotes/utils.rb
@@ -86,6 +86,41 @@ module Rbnotes
     end
     module_function :run_with_tmpfile
 
+    ##
+    # Generates a Textrepo::Timestamp object from a String which comes
+    # from the command line arguments.  When no argument is given,
+    # then reads from STDIN.
+    #
+    # :call-seq:
+    #   read_timestamp(args) -> String
+
+    def read_timestamp(args)
+      str = args.shift || read_arg($stdin)
+      begin
+        Textrepo::Timestamp.parse_s(str)
+      rescue ArgumentError => _
+        raise InvalidTimestampStringError, str
+      end
+    end
+    module_function :read_timestamp
+
+    ##
+    # Reads an argument from the IO object.  Typically, it is intended
+    # to be used with STDIN.
+    #
+    # :call-seq:
+    #   read_arg(IO) -> String
+
+    def read_arg(io)
+      # assumes the reading line looks like:
+      #
+      #     foo bar baz ...
+      #
+      # then, only the first string is interested
+      io.gets.split(" ")[0]
+    end
+    module_function :read_arg
+
     # :stopdoc:
 
     private

--- a/lib/rbnotes/version.rb
+++ b/lib/rbnotes/version.rb
@@ -1,4 +1,4 @@
 module Rbnotes
-  VERSION = "0.2.2"
-  RELEASE = '2020-10-27'
+  VERSION = "0.3.0"
+  RELEASE = '2020-10-29'
 end

--- a/test/fixtures/setup_test_repo.rb
+++ b/test/fixtures/setup_test_repo.rb
@@ -16,6 +16,7 @@ def copy_text(texts, repo_path, ye, mo, da, ho, mi, se, sfx)
   }
 
   texts.each { |abspath|
+    next if FileTest.empty?(abspath)
     t = stamps.shift
     dirname = File.expand_path(t.strftime("%Y/%m"), repo_path)
     basename = t.strftime("%Y%m%d%H%M%S")

--- a/test/rbnotes_commands_delete_test.rb
+++ b/test/rbnotes_commands_delete_test.rb
@@ -10,9 +10,7 @@ class RbnotesCommandsDeleteTest < Minitest::Test
   def test_that_it_can_delete_the_specified_note
     target_stamp = "20201016132900"
 
-    fixture_text_dir = File.expand_path("text", CONF_RO[:repository_base])
-    src_path = File.expand_path("apple.md", fixture_text_dir)
-
+    src_path = sample_text_path("apple.md")
     dst_path = prepare_note_from_file(target_stamp, src_path, repo_path(@conf_rw))
 
     result = execute(:delete, [target_stamp], @conf_rw)
@@ -27,5 +25,26 @@ class RbnotesCommandsDeleteTest < Minitest::Test
 
     result = execute(:delete, [stamp], @conf_rw)
     assert result.include?("missing timestamp")
+  end
+
+  def test_that_it_reads_arg_from_stdin_when_no_args
+    timestamp_str = "20201029170500"
+
+    sample = sample_text_path("cpu.md")
+    dst_path = prepare_note_from_file(timestamp_str, sample, repo_path(@conf_rw))
+
+    $stdin = StringIO.new(timestamp_str)
+    result = execute(:delete, [], @conf_rw)
+    $stdin = STDIN
+
+    assert result.include?("Delete")
+    assert result.include?(timestamp_str)
+    refute FileTest.exist?(dst_path)
+  end
+
+  private
+  def sample_text_path(basename)
+    File.expand_path(basename,
+                     File.expand_path("text", CONF_RO[:repository_base]))
   end
 end

--- a/test/rbnotes_commands_import_test.rb
+++ b/test/rbnotes_commands_import_test.rb
@@ -44,6 +44,12 @@ class RbnotesCommandsImportTest < Minitest::Test
     assert FileUtils.identical?(src_file, expected)
   end
 
+  def test_it_fails_to_import_empty_text
+    src_file = File.expand_path(File.join("fixtures", "text", "empty.md"), __dir__)
+    result = execute(:import, [src_file], @conf_rw)
+    assert result.include?("empty")
+  end
+
   private
   def expected_path(org_file)
     st = File::Stat.new(org_file)

--- a/test/rbnotes_commands_show_test.rb
+++ b/test/rbnotes_commands_show_test.rb
@@ -24,4 +24,16 @@ class RbnotesCommandsShowTest < Minitest::Test
       assert FileUtils.identical?(file, @pager_out)
     }
   end
+
+  def test_that_it_reads_arg_from_stdin_when_no_args
+    timestamp_str = "20201012005001"
+    file = timestamp_to_path(timestamp_str, repo_path(@conf_ro))
+
+    cmd = load_cmd(:show)
+    $stdin = StringIO.new(timestamp_str)
+    cmd.execute([], @conf_ro)
+    $stdin = STDIN
+
+    assert FileUtils.identical?(file, @pager_out)
+  end
 end

--- a/test/rbnotes_commands_update_test.rb
+++ b/test/rbnotes_commands_update_test.rb
@@ -13,11 +13,9 @@ class RbnotesCommandsUpdateTest < Minitest::Test
     timestamp = "20201022000000"
     prepare_note(timestamp, ["Hello!"], repo_path(@conf_rw))
 
-    result = execute("update", [timestamp], @conf_rw)
+    result = execute(:update, [timestamp], @conf_rw)
 
-    # extract the new timestamp from the execution result
-    newstamp = /-> ([0-9]+)\]/.match(result).to_a[1]
-    dst_note_path = timestamp_to_path(newstamp, repo_path(@conf_rw))
+    dst_note_path = extract_note_path(result)
     assert FileTest.exist?(dst_note_path)
 
     # the following assertion depends on the `fake_editor` behavior
@@ -37,6 +35,25 @@ class RbnotesCommandsUpdateTest < Minitest::Test
 
     # `result` must contain a message which says it does nothing
     assert result.include?("Nothing is updated")
+  end
+
+  def test_that_it_reads_arg_from_stdin_when_no_args
+    timestamp_str = "20201029170000"
+    prepare_note(timestamp_str, ["# Do you read me?"], repo_path(@conf_rw))
+
+    $stdin = StringIO.new(timestamp_str)
+    result = execute(:update, [], @conf_rw)
+    $stdin = STDIN
+
+    dst_note_path = extract_note_path(result)
+    assert FileTest.exist?(dst_note_path)
+  end
+
+  private
+  # extract the new timestamp from the execution result
+  def extract_note_path(str)
+    timestamp_str = /-> ([0-9]+)\]/.match(str).to_a[1]
+    timestamp_to_path(timestamp_str, repo_path(@conf_rw))
   end
 
 end


### PR DESCRIPTION
- modify show/updte/delete command to read standard input when no
  argument specified in the command line
- remove heading markup to print subject line (list)
- add an error to indicate to fail to convert a string into
  Textrepo::Timestamp object
- add some new tests for the feature
- bump version 0.2.2 -> 0.3.0

CHANGELOG.md was also updated for 0.3.0.
This PR will close #27.