### PR TITLE
fix: Rbnotes::Utils.read_arg returns nil when it reads nil

### DIFF
--- a/lib/rbnotes/utils.rb
+++ b/lib/rbnotes/utils.rb
@@ -113,7 +113,11 @@ module Rbnotes
       #     foo bar baz ...
       #
       # then, only the first string is interested
-      io.gets.split(" ")[0]
+      begin
+        io.gets.split(" ")[0]
+      rescue NoMethodError => _
+        nil
+      end
     end
     module_function :read_arg
 

--- a/test/rbnotes_utils_test.rb
+++ b/test/rbnotes_utils_test.rb
@@ -59,11 +59,19 @@ class RbnotesUtilsTest < Minitest::Test
 
   # run_with_tmpfile(prog, filename)
   def test_run_with_tmpfile_can_handle_a_tmpefile
-    tmpfile = File.expand_path("rbnotes_utils_test_run_with_tmpfile.txt", Dir.tmpdir)
+    tmpname = "rbnotes_utils_test_run_with_tmpfile"
     program = File.expand_path("fake_editor", __dir__)
-    rc = system(program, tmpfile)
+
+    tmpfile = Rbnotes::Utils.run_with_tmpfile(program, tmpname)
 
     @clean_files << tmpfile
-    assert rc && FileTest.exist?(tmpfile)
+    assert tmpfile && FileTest.exist?(tmpfile)
+  end
+
+  # read_arg(io)
+  def test_read_arg_returns_nil_when_reads_nil_from_io
+    nilio = StringIO.new
+    arg = Rbnotes::Utils.read_arg(nilio)
+    assert arg.nil?
   end
 end


### PR DESCRIPTION
[issue #30]
- fix Rbnotes::Utils.read_arg
- fix a test in rbnotes_utils_test.rb

This PR will fix #30.