### PR TITLE
fix: add help for search command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 Rbnotes is a simple utility to write a note in the single repository.
 
+This document provides the basic information to use rbnotes.
+You may find more useful information in [Wiki pages](https://github.com/mnbi/rbnotes/wiki).
+
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -39,6 +42,8 @@ rbnotes [global_opts] [command] [command_opts] [args]
   - imports existing files
 - list
   - lists notes in the repository with their timestamps and subject
+- search
+  - search a word (or words) in the repository
 - show
   - shows the content of a note
 - add
@@ -145,6 +150,38 @@ The short-hand notation of the home directory ("~") is usable.
 
 - :pager : specify a pager program
 - :editor : specify a editor program
+- :searcher: specify a program to perform search
+- :searcher_options: specify options to pass to the searcher program
+
+Be careful to set `:searcher` and `:searcher_options`. The searcher
+program must be expected to behave equivalent to `grep` with `-inRE`.
+At least, its output must be the same format and it must runs
+recursively to a directory.
+
+If your favorite searcher is one of the followings, see the default
+options which `textrepo` sets for those searchers.  In most cases, you
+don't have to set `:searcher_options` for them.
+
+| searcher | default options in `textrepo`                      |
+|:---------|:---------------------------------------------------|
+| `grep`   | `["-i", "-n", "-R", "-E"]`                         |
+| `egrep`  | `["-i", "-n", "-R"]`                               |
+| `ggrep`  | `["-i", "-n", "-R", "-E"]`                         |
+| `gegrep` | `["-i", "-n", "-R"]`                               |
+| `rg`     | `["-S", "-n", "--no-heading", "--color", "never"]` |
+
+Those searcher names are used in macOS (with Homebrew).  Any other OS
+might use different names.
+
+- `grep` and `egrep` -> BSD grep (macOS default)
+- `ggrep` and `gegrep` -> GNU grep
+- `rg` -> ripgrep
+
+If the name is different, `:searcher_options` should be set with the
+same value.  For example, if you system use the name `gnugrep` as GNU
+grep, and you want to use it as the searcher (that is, set `gnugrep`
+to `:searcher`), you should set `:searcher_options` value with `["-i",
+"-n", "-R", "-E"]`.
 
 ##### Default values for mandatory variables
 

--- a/lib/rbnotes/commands.rb
+++ b/lib/rbnotes/commands.rb
@@ -32,23 +32,36 @@ module Rbnotes
       class Help < Command
         def execute(_, _)
           puts <<USAGE
-usage: rbnotes [-c|--conf CONF_FILE] [command] [args]
+usage:
+    rbnotes [-c|--conf CONF_FILE] [command] [args]
+
+option:
+    -c, --conf [CONF_FILE] : specifiy the configuration file
+
+    CONF_FILE must be written in YAML.  To know about details of the
+    configuration file, see README.md or Wiki page.
 
 command:
     add            : create a new note
     import FILE    : import a FILE into the repository
 
-    list PATTERN   : list notes those timestamp matches PATTERN
+    list [STAMP_PATTERN] : list notes those timestamp matches PATTERN
+    search PATTERN [STAMP_PATTERN] : search PATTERN
 
-    PATTERN must be:
+    STAMP_PATTERN must be:
+
         (a) full qualified timestamp (with suffix): "20201030160200"
         (b) year and date part: "20201030"
-        (c) year part only: "2020"
-        (d) date part only: "1030"
+        (c) year and month part: "202010"
+        (d) year part only: "2020"
+        (e) date part only: "1030"
 
-    show STAMP     : show the note specified with STAMP
-    update STAMP   : edit the note with external editor
-    delete STAMP   : delete the note specified with STAMP
+    PATTERN is a word (or words) to search, it may also be a regular
+    expression.
+
+    show   [STAMP] : show the note specified with STAMP
+    update [STAMP] : edit the note with external editor
+    delete [STAMP] : delete the note specified with STAMP
 
     STAMP must be a sequence of digits to represent year, date and
     time (and suffix), such "20201030160200" or "20201030160200_012".
@@ -59,11 +72,15 @@ command:
     version        : print version
     help           : show help
 
-commands for development purpose:
+command for development:
     conf           : print the current configuraitons
     repo           : print the repository path
     stamp TIME_STR : convert TIME_STR into a timestamp
     time  STAMP    : convert STAMP into a time string
+
+For more information, see Wiki page.
+    - https://github.com/mnbi/rbnotes/wiki
+
 USAGE
         end
       end

--- a/lib/rbnotes/commands/search.rb
+++ b/lib/rbnotes/commands/search.rb
@@ -1,29 +1,27 @@
-# :markup: markdown
-
-##
-# Searches a given pattern in notes those have timestamps match a
-# given timestamp pattern.  The first argument is a pattern to search.
-# It is a String object represents a portion of text or it may a
-# String represents a regular expression.  The second argument is
-# optional and it is a timestamp pattern to specify the search target.
-#
-# A pattern for search is mandatory.  If no pattern, raises
-# Rbnotes::MissingArgumentError.
-#
-# Example of PATTERN:
-#     ""rbnotes" (a word)
-#     "macOS Big Sur" (a few words)
-#     "2[0-9]{3}(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])" (a regular expression)
-#
-# A timestamp pattern is optional.  If no timestamp pattern, all notes
-# in the repository would be target of search.
-#
-# See the document of `Rbnotes::Commands::List#execute` to know about
-# a timestamp pattern.
-
-# :stopdoc: 
-
 module Rbnotes
+
+  ##
+  # Searches a given pattern in notes those have timestamps match a
+  # given timestamp pattern.  The first argument is a pattern to search.
+  # It is a String object represents a portion of text or it may a
+  # String represents a regular expression.  The second argument is
+  # optional and it is a timestamp pattern to specify the search target.
+  #
+  # A pattern for search is mandatory.  If no pattern, raises
+  # Rbnotes::MissingArgumentError.
+  #
+  # Example of PATTERN for search:
+  #
+  #   "rbnotes" (a word)
+  #   "macOS Big Sur" (a few words)
+  #   "2[0-9]{3}(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])" (a regular expression)
+  #
+  # A timestamp pattern is optional.  If no timestamp pattern, all notes
+  # in the repository would be target of search.
+  #
+  # See the document of `Rbnotes::Commands::List#execute` to know about
+  # a timestamp pattern.
+
   class Commands::Search < Commands::Command
     def execute(args, conf)
       pattern = args.shift


### PR DESCRIPTION
[issue #31, #38, #39, #40]
- add help text for search command (#40)
- add description about "yyyymo" pattern in help (#40)
- fix rdoc comment of Rbnotes::Commands::Search (#39)
- add description about how to set searcher and its options (#38)
- add a link to Wiki pages in README.md (#31)

This PR will:
- fix #40,
- close #39,
- close #38,
- close #31.