### PR TITLE
feat: add feature to keep the timestamp in update command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 Nothing to record here.
 
+## [0.4.2] - 2020-11-05
+### Added
+- Add a feature to keep the timestamp in `update` command. (#44)
+
+### Changed
+- Fix issue #45: hanging up of `add` command.
+
 ## [0.4.1] - 2020-11-04
 ### Added
 - Add a feature to accept a timestamp in `add` command. (#34)

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ gemspec
 gem "rake", "~> 13.0"
 gem "minitest", "~> 5.0"
 
-gem 'textrepo', "~> 0.5"
+gem 'textrepo', "~> 0.5.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    rbnotes (0.4.1)
-      textrepo (~> 0.5)
+    rbnotes (0.4.2)
+      textrepo (~> 0.5.4)
       unicode-display_width (~> 1.7)
 
 GEM
@@ -10,7 +10,7 @@ GEM
   specs:
     minitest (5.14.2)
     rake (13.0.1)
-    textrepo (0.5.3)
+    textrepo (0.5.4)
     unicode-display_width (1.7.0)
 
 PLATFORMS
@@ -20,7 +20,7 @@ DEPENDENCIES
   minitest (~> 5.0)
   rake (~> 13.0)
   rbnotes!
-  textrepo (~> 0.5)
+  textrepo (~> 0.5.4)
 
 BUNDLED WITH
    2.1.4

--- a/lib/rbnotes/commands/add.rb
+++ b/lib/rbnotes/commands/add.rb
@@ -41,6 +41,7 @@ module Rbnotes::Commands
           @opts[:timestamp] = Textrepo::Timestamp.parse_s(stamp_str)
         else
           args.unshift(arg)
+          break
         end
       end
 

--- a/lib/rbnotes/version.rb
+++ b/lib/rbnotes/version.rb
@@ -1,4 +1,4 @@
 module Rbnotes
-  VERSION = "0.4.1"
-  RELEASE = "2020-11-04"
+  VERSION = "0.4.2"
+  RELEASE = "2020-11-05"
 end

--- a/rbnotes.gemspec
+++ b/rbnotes.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "textrepo", "~> 0.5"
+  spec.add_dependency "textrepo", "~> 0.5.4"
   spec.add_dependency "unicode-display_width", "~> 1.7"
 end

--- a/test/rbnotes_commands_add_test.rb
+++ b/test/rbnotes_commands_add_test.rb
@@ -9,7 +9,7 @@ class RbnotesCommandsAddTest < Minitest::Test
   end
 
   def test_that_it_can_create_a_new_note
-    assert_success_to_add(nil, true)
+    assert_success_to_add_with_timestamp(nil, true)
   end
 
   def test_that_it_fails_to_crete_with_empty_content
@@ -24,19 +24,19 @@ class RbnotesCommandsAddTest < Minitest::Test
   # for `-t STAMP_PATTERN`
 
   def test_it_accepts_stamp_pattern_full_qualified
-    assert_success_to_add("20201104170400", false)
+    assert_success_to_add_with_timestamp("20201104170400", false)
   end
 
   def test_it_accepts_stamp_pattern_full_qualified_with_suffix
-    assert_success_to_add("20201104170400_012", false)
+    assert_success_to_add_with_timestamp("20201104170400_012", false)
   end
 
   def test_it_accepts_stamp_pattern_omit_sec_part
-    assert_success_to_add("202011041705", false)
+    assert_success_to_add_with_timestamp("202011041705", false)
   end
 
   def test_it_accepts_stamp_pattern_omit_year_and_sec_part
-    assert_success_to_add("11041706", false)
+    assert_success_to_add_with_timestamp("11041706", false)
   end
 
   def test_it_fails_with_nil_as_pattern
@@ -51,11 +51,20 @@ class RbnotesCommandsAddTest < Minitest::Test
     }
   end
 
+  # [issue #45]
+  def test_it_ignores_extra_arguments_in_wrong_syntax
+    result = execute(:add, ["apple", "imac", "2020"], @conf_rw)
+    assert_success_to_add(result)
+  end
+
   private
-  def assert_success_to_add(pattern = nil, cleanup = true)
+  def assert_success_to_add_with_timestamp(pattern = nil, cleanup = true)
     args = pattern.nil? ? [] : ["-t", pattern]
     result = execute(:add, args, @conf_rw)
+    assert_success_to_add(result, cleanup)
+  end
 
+  def assert_success_to_add(result, cleanup = true)
     stamp_str = /[A-z ]+\[([0-9_]+)\]/.match(result).to_a[1]
     refute stamp_str.nil?
 
@@ -64,4 +73,5 @@ class RbnotesCommandsAddTest < Minitest::Test
 
     FileUtils.rm_f(note_path) if cleanup
   end
+
 end


### PR DESCRIPTION
[issue #44, 45]
- add an option, "-k" or "--keep" in update command
- add tests for the feature
- refactor tests for Rbnotes::Commands::Update
- fix hanging up of add command (#45)
- bump version: 0.4.1 -> 0.4.2

This PR will:
- close #44,
- fix #45.