### PR TITLE
fix: add fails without modification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+- Fix `add` fails without modification (#48)
 - Add individual help for each command. (#42)
 
 

--- a/lib/rbnotes/commands/add.rb
+++ b/lib/rbnotes/commands/add.rb
@@ -56,6 +56,12 @@ module Rbnotes::Commands
       raise Rbnotes::NoEditorError, candidates if editor.nil?
 
       tmpfile = run_with_tmpfile(editor, stamp.to_s)
+
+      unless FileTest.exist?(tmpfile)
+        puts "Cancel adding, since nothing to store"
+        return
+      end
+
       text = File.readlines(tmpfile)
 
       repo = Textrepo.init(conf)

--- a/test/rbnotes_commands_add_test.rb
+++ b/test/rbnotes_commands_add_test.rb
@@ -57,6 +57,15 @@ class RbnotesCommandsAddTest < Minitest::Test
     assert_success_to_add(result)
   end
 
+  # [issue #48]
+  def test_it_does_nothing_when_no_modification_in_the_editor
+    conf = @conf_rw.dup
+    conf[:editor] = File.expand_path("fake_editor_do_nothing", __dir__)
+    result = execute(:add, [], conf)
+    refute_empty result
+    assert_includes result, "Cancel"
+  end
+
   private
   def assert_success_to_add_with_timestamp(pattern = nil, cleanup = true)
     args = pattern.nil? ? [] : ["-t", pattern]


### PR DESCRIPTION
[issue #48]
- modify to do nothing when no modification was made

This PR will fix #48.