### PR TITLE
fix: list command crash in a pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
-Nothing to record here.
+- Fix issue #61: `list` command fails in pipeline.
 
 ## [0.4.6] - 2020-11-13
 ### Added

--- a/exe/rbnotes
+++ b/exe/rbnotes
@@ -48,6 +48,11 @@ app = App.new
 begin
   app.parse_global_options(ARGV)
   app.run(ARGV)
+rescue Errno::EPIPE => e
+  # Fix issue #61: When the pipeline which rbnotes connects is
+  # discarded by the other program, the execption was raised.  It does
+  # not end abnormally for rbnotes.  So, just ignores the exception.
+  exit 0
 rescue MissingArgumentError, MissingTimestampError,
        NoEditorError, ProgramAbortError,
        Textrepo::InvalidTimestampStringError,


### PR DESCRIPTION
[issue #61]
- add a "rescue" clause in the top level of rbnotes to catche the
  exception of broken pipe

This PR will fix #61.