### PR TITLE
fix: messy output of the search result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 Nothing to record here.
 
+## [0.4.8] - 2020-11-16
+### Fixed
+- Fix issue #65: messy output of the `search` command.
+
 ## [0.4.7] - 2020-11-15
 ### Changed
 - Beautify output of the `search` command. (#63)
@@ -35,7 +39,7 @@ Nothing to record here.
 - Add individual help for each command. (#42)
 
 ### Fixed
-- Fix `add` fails without modification (#48)
+- Fix issue #48: `add` fails without modification.
 
 ## [0.4.2] - 2020-11-05
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rbnotes (0.4.7)
+    rbnotes (0.4.8)
       textrepo (~> 0.5.4)
       unicode-display_width (~> 1.7)
 
@@ -10,7 +10,7 @@ GEM
   specs:
     minitest (5.14.2)
     rake (13.0.1)
-    textrepo (0.5.6)
+    textrepo (0.5.7)
     unicode-display_width (1.7.0)
 
 PLATFORMS

--- a/lib/rbnotes/commands/search.rb
+++ b/lib/rbnotes/commands/search.rb
@@ -77,11 +77,15 @@ HELP
       def timestamp_size
         timestamp.to_s.size
       end
+
+      def line_number_digits_size
+        line_number.to_s.size
+      end
     }
 
     def print_search_result(entries)
       maxcol_stamp = entries.map(&:timestamp_size).max
-      maxcol_num = entries.map(&:line_number).max
+      maxcol_num = entries.map(&:line_number_digits_size).max
 
       sort(entries).each { |e|
         stamp_display = "%- *s" % [maxcol_stamp, e.timestamp]

--- a/lib/rbnotes/version.rb
+++ b/lib/rbnotes/version.rb
@@ -1,4 +1,4 @@
 module Rbnotes
-  VERSION = "0.4.7"
-  RELEASE = "2020-11-15"
+  VERSION = "0.4.8"
+  RELEASE = "2020-11-16"
 end


### PR DESCRIPTION
[issue #65]
- fix how to calculate number of digits of the line number
- bump version: 0.4.7 -> 0.4.8

This PR will fix #65.