### PR TITLE
feat: add an option "--week" to the "list" command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 Nothing to record here.
 
+## [0.4.9] - 2020-11-17
+### Added
+- Add a new option `--week` to the `list` command. (#67)
+
 ## [0.4.8] - 2020-11-16
 ### Fixed
 - Fix issue #65: messy output of the `search` command.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rbnotes (0.4.8)
+    rbnotes (0.4.9)
       textrepo (~> 0.5.4)
       unicode-display_width (~> 1.7)
 

--- a/lib/rbnotes/error.rb
+++ b/lib/rbnotes/error.rb
@@ -7,11 +7,12 @@ module Rbnotes
   # :stopdoc:
 
   module ErrMsg
-    MISSING_ARGUMENT  = "missing argument: %s"
-    MISSING_TIMESTAMP = "missing timestamp: %s"
+    MISSING_ARGUMENT  = "Missing argument: %s"
+    MISSING_TIMESTAMP = "Missing timestamp: %s"
     NO_EDITOR         = "No editor is available: %s"
     PROGRAM_ABORT     = "External program was aborted: %s"
     UNKNOWN_KEYWORD   = "Unknown keyword: %s"
+    INVALID_TIMESTAMP_PATTERN = "Invalid timestamp pattern: %s"
   end
 
   # :startdoc:
@@ -64,4 +65,14 @@ module Rbnotes
       super(ErrMsg::UNKNOWN_KEYWORD % keyword)
     end
   end
+
+  ##
+  # An error raised when an invalid timestamp pattern was specified.
+
+  class InvalidTimestampPatternError < Error
+    def initialize(pattern)
+      super(ErrMsg::INVALID_TIMESTAMP_PATTERN % pattern)
+    end
+  end
+
 end

--- a/lib/rbnotes/utils.rb
+++ b/lib/rbnotes/utils.rb
@@ -227,6 +227,17 @@ module Rbnotes
       }.flatten.sort{ |a, b| b <=> a }.uniq
     end
 
+    ##
+    # Enumerates all timestamp patterns in a week which contains a
+    # given timestamp as a day of the week.
+    #
+    # :call-seq:
+    #     timestamp_patterns_in_week(timestamp) -> [Array of Strings]
+
+    def timestamp_patterns_in_week(timestamp)
+      dates_in_week(start_date_in_the_week(timestamp.time)).map { |date| timestamp_pattern(date) }
+    end
+
     # :stopdoc:
 
     private
@@ -268,12 +279,16 @@ module Rbnotes
     end
 
     def start_date_in_this_week
-      today = Time.now
-      Date.new(today.year, today.mon, today.day).prev_day(wday(today))
+      start_date_in_the_week(Time.now)
     end
 
     def start_date_in_last_week
       start_date_in_this_week.prev_day(7)
+    end
+
+    def start_date_in_the_week(time)
+      parts = [:year, :mon, :day].map { |sym| time.send(sym) }
+      Date.new(*parts).prev_day(wday(time))
     end
 
     def wday(time)

--- a/lib/rbnotes/version.rb
+++ b/lib/rbnotes/version.rb
@@ -1,4 +1,4 @@
 module Rbnotes
-  VERSION = "0.4.8"
-  RELEASE = "2020-11-16"
+  VERSION = "0.4.9"
+  RELEASE = "2020-11-17"
 end

--- a/test/rbnotes_utils_test.rb
+++ b/test/rbnotes_utils_test.rb
@@ -74,4 +74,25 @@ class RbnotesUtilsTest < Minitest::Test
     arg = Rbnotes.utils.read_arg(nilio)
     assert arg.nil?
   end
+
+  # timestamps_in_week(timestamp)
+  def test_timestamp_patterns_in_week_enumerates_timestamps
+    a_day = Textrepo::Timestamp.new(Time.new(2020, 11, 17, 0, 0, 0))
+    days_of_week = [
+      "2020-11-16",             # Mon
+      "2020-11-17",             # Tue
+      "2020-11-18",             # Wed
+      "2020-11-19",             # Thu
+      "2020-11-20",             # Fri
+      "2020-11-21",             # Sat
+      "2020-11-22",             # Sun
+    ].map { |d| d.tr("-", "") }
+    days = Rbnotes.utils.timestamp_patterns_in_week(a_day)
+    refute days.nil?
+    assert_equal 7, days.size
+
+    days.sort!
+
+    assert_equal days_of_week, days
+  end
 end


### PR DESCRIPTION
[issue #67]
- modify "Rbnotes::Commands::List#execute" to accept an option "--week"
- add help about this option
- add an error to indicate an invalid timestamp pattern
- add a method to enumerate timestamp pattern in a week in "Rbnotes::Utils"
- add a test for "Rbnotes::Utils#timetamp_patterns_in_week"
- bump version: 0.4.8 -> 0.4.9

This PR will close #67.