### PR TITLE
fix: crashes with InvalidTimestampPatternError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
-Nothing to record here.
+- Fix issue #69: crashes with invalid timestamp pattern.
 
 ## [0.4.9] - 2020-11-17
 ### Added

--- a/exe/rbnotes
+++ b/exe/rbnotes
@@ -56,6 +56,7 @@ rescue Errno::EPIPE => e
 rescue MissingArgumentError, MissingTimestampError,
        NoEditorError, ProgramAbortError,
        Textrepo::InvalidTimestampStringError,
+       InvalidTimestampPatternError,
        ArgumentError,
        Errno::EACCES => e
   puts e.message


### PR DESCRIPTION
- add InvalidTimestampPatternError to the rescue clause of the top
  level of rbnotes.

This PR will fix #69.