### PR TITLE
feat: add yearly and monthly report to `statistics` command

### DIFF
--- a/lib/rbnotes.rb
+++ b/lib/rbnotes.rb
@@ -8,6 +8,7 @@ module Rbnotes
   require_relative "rbnotes/conf"
   require_relative "rbnotes/utils"
   require_relative "rbnotes/commands"
+  require_relative "rbnotes/statistics"
 
   class << self
     def utils

--- a/lib/rbnotes/commands.rb
+++ b/lib/rbnotes/commands.rb
@@ -65,7 +65,7 @@ Example usage:
   #{Rbnotes::NAME} list [STAMP_PATTERN|KEYWORD]
   #{Rbnotes::NAME} search PATTERN [STAMP_PATTERN]
   #{Rbnotes::NAME} show [TIMESTAMP]
-  #{Rbnotes::NAME} statistics
+  #{Rbnotes::NAME} statistics ([-y]|[-m])
   #{Rbnotes::NAME} update [-k] [TIMESTAMP]
 
 Further help for each command:

--- a/lib/rbnotes/commands/statistics.rb
+++ b/lib/rbnotes/commands/statistics.rb
@@ -9,18 +9,45 @@ module Rbnotes::Commands
     end
 
     def execute(args, conf)
-      @opts = {}
+      report = :total
+      while args.size > 0
+        arg = args.shift
+        case arg
+        when "-y", "--yearly"
+          report = :yearly
+          break
+        when "-m", "--monthly"
+          report = :monthly
+          break
+        else
+          args.unshift(arg)
+          raise ArgumentError, "invalid option or argument: %s" % args.join(" ")
+        end
+      end
 
-      repo = Textrepo.init(conf)
-      puts repo.entries.size
+      stats = Rbnotes::Statistics.new(conf)
+      case report
+      when :yearly
+        stats.yearly_report
+      when :monthly
+        stats.monthly_report
+      else
+        stats.total_report
+      end
     end
 
     def help
       puts <<HELP
 usage:
-    #{Rbnotes::NAME} statistics
+    #{Rbnotes::NAME} statistics ([-y|--yearly]|[-m|--monthly])
+
+option:
+    -y, --yearly  : print yearly report
+    -m, --monthly : print monthly report
 
 Show statistics.
+
+In the version #{Rbnotes::VERSION}, only number of notes is supported.
 HELP
     end
 

--- a/lib/rbnotes/statistics.rb
+++ b/lib/rbnotes/statistics.rb
@@ -1,0 +1,101 @@
+module Rbnotes
+  ##
+  # Calculates statistics of the repository.
+  class Statistics
+    include Enumerable
+
+    def initialize(conf)
+      @repo = Textrepo.init(conf)
+      @values = construct_values(@repo)
+    end
+
+    def total_report
+      puts @repo.entries.size
+    end
+
+    def yearly_report
+      self.each_year { |year, monthly_values|
+        num_of_notes = monthly_values.map { |_mon, values| values.size }.sum
+        puts "#{year}: #{num_of_notes}"
+      }
+    end
+
+    def monthly_report
+      self.each { |year, mon, values|
+        num_of_notes = values.size
+        puts "#{year}/#{mon}: #{num_of_notes}"
+      }
+    end
+
+    def each(&block)
+      if block.nil?
+        @values.map { |year, monthly_values|
+          monthly_values.each { |mon, values|
+            [year, mon, values]
+          }
+        }.to_enum(:each)
+      else
+        @values.each { |year, monthly_values|
+          monthly_values.each { |mon, values|
+            yield [year, mon, values]
+          }
+        }
+      end
+    end
+
+    def years
+      @values.keys
+    end
+
+    def months(year)
+      @values[year] || []
+    end
+
+    def each_year(&block)
+      if block.nil?
+        @values.map { |year, monthly_values|
+          [year, monthly_values]
+        }.to_enum(:each)
+      else
+        @values.each { |year, monthly_values|
+          yield [year, monthly_values]
+        }
+      end
+    end
+
+    private
+
+    def construct_values(repo)
+      values = {}
+      repo.each { |timestamp, text|
+        value = StatisticValue.new(timestamp, text)
+        y = value.year
+        m = value.mon
+        values[y] ||= {}
+        values[y][m] ||= []
+
+        values[y][m] << value
+      }
+      values
+    end
+
+    class StatisticValue
+
+      attr_reader :lines
+
+      def initialize(timestamp, text)
+        @timestamp = timestamp
+        @lines = text.size
+      end
+
+      def year
+        @timestamp[:year]
+      end
+
+      def mon
+        @timestamp[:mon]
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
[issue #73]
- add "-y" and "-m" option to `statistics` command
- add a class Rbnotes::Statistics which calculate statistics of
  the repository
- test for the feature have not been written yet, they will be added
  in the next commit