### PR TITLE
fix: modify to raise an error if non-existing conf file was specifed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+- Fix issue #77: no error with a non-existing config file.
 - Add a new command `statistics`. (#73)
   - limited features
 - Add a completion file for `zsh`.

--- a/exe/rbnotes
+++ b/exe/rbnotes
@@ -57,6 +57,7 @@ rescue MissingArgumentError, MissingTimestampError,
        NoEditorError, ProgramAbortError,
        Textrepo::InvalidTimestampStringError,
        InvalidTimestampPatternError,
+       NoConfFileError,
        ArgumentError,
        Errno::EACCES => e
   puts e.message

--- a/lib/rbnotes/conf.rb
+++ b/lib/rbnotes/conf.rb
@@ -32,16 +32,18 @@ module Rbnotes
     DIRNAME_COMMON_CONF = ".config"
 
     def initialize(conf_path = nil)   # :nodoc:
-      @conf_path = conf_path || File.join(base_path, FILENAME_CONF)
-
+      @conf_path = conf_path
       @conf = {}
-      if FileTest.exist?(@conf_path)
+
+      if use_default_values?
+        @conf.merge!(DEFAULT_VALUES)
+      else
+        @conf_path ||= default_conf_file
+        raise NoConfFileError, @conf_path unless File.exist?(@conf_path)
+
         yaml_str = File.open(@conf_path, "r") { |f| f.read }
         @conf = YAML.load(yaml_str)
-      else
-        @conf.merge(DEFAULT_VALUES)
       end
-      self
     end
 
     def_delegators(:@conf,
@@ -99,9 +101,18 @@ module Rbnotes
       end
       return path
     end
-  end
+
+    def default_conf_file
+      File.join(base_path, FILENAME_CONF)
+    end
+
+    def use_default_values?
+      @conf_path.nil? && !File.exist?(default_conf_file)
+    end
 
   # :startdoc:
+
+  end
 
   class << self
     ##

--- a/lib/rbnotes/error.rb
+++ b/lib/rbnotes/error.rb
@@ -13,6 +13,7 @@ module Rbnotes
     PROGRAM_ABORT     = "External program was aborted: %s"
     UNKNOWN_KEYWORD   = "Unknown keyword: %s"
     INVALID_TIMESTAMP_PATTERN = "Invalid timestamp pattern: %s"
+    NO_CONF_FILE      = "No configuration file: %s"
   end
 
   # :startdoc:
@@ -72,6 +73,16 @@ module Rbnotes
   class InvalidTimestampPatternError < Error
     def initialize(pattern)
       super(ErrMsg::INVALID_TIMESTAMP_PATTERN % pattern)
+    end
+  end
+
+  ##
+  # An error raised when the specified configuration file does not
+  # exist.
+
+  class NoConfFileError < Error
+    def initialize(filename)
+      super(ErrMsg::NO_CONF_FILE % filename)
     end
   end
 

--- a/test/rbnotes_conf_test.rb
+++ b/test/rbnotes_conf_test.rb
@@ -83,6 +83,17 @@ class RbnotesConfTest < Minitest::Test
   end
 
   def test_it_generate_repository_name_suitable_to_run_mode
+    prepare_conf_file
+
+    conf = Rbnotes.conf(CONF_TEST_PATH)
+    assert conf[:repository_name].end_with?("_test")
+  end
+
+  # [issue #77]
+  def test_it_fails_when_the_specified_conf_file_does_not_exist
+    assert_raises(Rbnotes::NoConfFileError) {
+      Rbnotes.conf("conf_hoge.yml")
+    }
   end
 
   private
@@ -119,6 +130,6 @@ class RbnotesConfTest < Minitest::Test
   def prepare_conf(path)
     conf = CONF_BASE.dup
     conf[:run_mode] = :test
-    write_conf_file(conf, path)
+    write_conf_file(conf, path) unless File.exist?(path)
   end
 end


### PR DESCRIPTION
[issue #77]
- modify Rbnotes::Conf#initialize
- add an error, Rbnotes::NoConfFileError
- modify to catch a new error in the top level
- add a test for the issue

This PR will fix #77.