### PR TITLE
feat: add an option for `import` to use `mtime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
-- Add a feature to show multiple notes at once. (#79)
-- Fix issue #77: no error with a non-existing config file.
+## [0.4.11] - 2020-12-07
+### Added
 - Add a new command `statistics`. (#73)
   - limited features
 - Add a completion file for `zsh`.
   - a new file `etc/zsh/_rbnotes`
+
+### Changed
+- Add a new option for `import` to use `mtime`. (#82)
+- Add a feature to show multiple notes at once. (#79)
+
+### Fixed
+- Fix issue #77: no error with a non-existing config file.
 
 ## [0.4.10] - 2020-11-20
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rbnotes (0.4.10)
+    rbnotes (0.4.11)
       textrepo (~> 0.5.4)
       unicode-display_width (~> 1.7)
 

--- a/lib/rbnotes/commands.rb
+++ b/lib/rbnotes/commands.rb
@@ -61,7 +61,7 @@ Example usage:
   #{Rbnotes::NAME} commands [-d]
   #{Rbnotes::NAME} delete [TIMESTAMP]
   #{Rbnotes::NAME} export [TIMESTAMP [FILENAME]]
-  #{Rbnotes::NAME} import FILE
+  #{Rbnotes::NAME} import [-m|--use-mtime] FILE
   #{Rbnotes::NAME} list [STAMP_PATTERN|KEYWORD]
   #{Rbnotes::NAME} search PATTERN [STAMP_PATTERN]
   #{Rbnotes::NAME} show [TIMESTAMP...]

--- a/lib/rbnotes/version.rb
+++ b/lib/rbnotes/version.rb
@@ -1,4 +1,4 @@
 module Rbnotes
-  VERSION = "0.4.10"
-  RELEASE = "2020-11-20"
+  VERSION = "0.4.11"
+  RELEASE = "2020-12-07"
 end

--- a/test/rbnotes_commands_import_test.rb
+++ b/test/rbnotes_commands_import_test.rb
@@ -9,7 +9,8 @@ class RbnotesCommandsImportTest < Minitest::Test
   end
 
   def teardown
-    FileUtils.rm_r(repo_path(@conf_rw))
+    path = repo_path(@conf_rw)
+    FileUtils.rm_r(path) if FileTest.exist?(path)
   end
 
   def test_that_it_can_import_an_existing_file


### PR DESCRIPTION
[issue #82]
- modify Import#execute to accept the new option
- add a test for the new option
- bump version: 0.4.10 -> 0.4.11

This PR will close #82.