### PR TITLE
fix: show command complains

### DIFF
--- a/exe/rbnotes
+++ b/exe/rbnotes
@@ -48,10 +48,16 @@ app = App.new
 begin
   app.parse_global_options(ARGV)
   app.run(ARGV)
-rescue Errno::EPIPE => e
+rescue Errno::EPIPE => _
   # Fix issue #61: When the pipeline which rbnotes connects is
   # discarded by the other program, the execption was raised.  It does
   # not end abnormally for rbnotes.  So, just ignores the exception.
+  exit 0
+rescue NoArgumentError => _
+  # Fix issue #80: Typically, this error raises when a command tries
+  # to read the standard input for its arguments and gets nil.  It
+  # means user wants to cancel to execute.  So, just ignore the error
+  # and exit.
   exit 0
 rescue MissingArgumentError, MissingTimestampError,
        NoEditorError, ProgramAbortError,

--- a/lib/rbnotes/error.rb
+++ b/lib/rbnotes/error.rb
@@ -86,4 +86,13 @@ module Rbnotes
     end
   end
 
+  ##
+  # An error raised when no arguments is spcified.
+
+  class NoArgumentError < Error
+    def initialize
+      super
+    end
+  end
+
 end

--- a/lib/rbnotes/utils.rb
+++ b/lib/rbnotes/utils.rb
@@ -99,6 +99,7 @@ module Rbnotes
 
     def read_timestamp(args)
       str = args.shift || read_arg($stdin)
+      raise NoArgumentError if str.nil?
       Textrepo::Timestamp.parse_s(str)
     end
 
@@ -112,6 +113,7 @@ module Rbnotes
 
     def read_multiple_timestamps(args)
       strings = args.size < 1 ? read_multiple_args($stdin) : args
+      raise NoArgumentError if (strings.nil? || strings.empty?)
       strings.map { |str| Textrepo::Timestamp.parse_s(str) }
     end
 


### PR DESCRIPTION
[issue #80]
- add an error to indicate reading nil from the standard input
- modify to raise an error when read nil in
  Rbnotes::Utils.read_timestamp
- modify to catch the error at the top level

This PR will close #80.