### PR TITLE
feat: add verbose mode for list command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+- Add a new option, `verbose` for `list` command. (#76)
 - Fix issue #80: suppress unnecessary error message.
 
 ## [0.4.11] - 2020-12-07

--- a/lib/rbnotes/utils.rb
+++ b/lib/rbnotes/utils.rb
@@ -185,25 +185,28 @@ module Rbnotes
     # Makes a headline with the timestamp and subject of the notes, it
     # looks like as follows:
     #
-    #   |<------------------ console column size ------------------->|
-    #   +-- timestamp ---+  +-  subject (the 1st line of each note) -+
-    #   |                |  |                                        |
-    #   20101010001000_123: I love Macintosh.                        [EOL]
-    #   20100909090909_999: This is very very long long loooong subje[EOL]
-    #                     ++
-    #                      ^--- delimiter (2 characters)
+    #   |<--------------- console column size -------------------->|
+    #   |   |+-- timestamp ---+  +-subject (the 1st line of note) -+
+    #   |                     |  |                                 |
+    #   |   |20101010001000_123: I love Macintosh.                 [EOL]
+    #   |   |20100909090909_999: This is very very long looong subj[EOL]
+    #   |<->|                 |  |
+    #     ^--- pad             ++
+    #                          ^--- delimiter (2 characters)
     #
     # The subject part will truncate when it is long.
 
-    def make_headline(timestamp, text)
+    def make_headline(timestamp, text, pad = nil)
       _, column = IO.console_size
       delimiter = ": "
       timestamp_width = timestamp.to_s.size
       subject_width = column - timestamp_width - delimiter.size - 1
+      subject_width -= pad.size unless pad.nil?
 
       subject = remove_heading_markup(text[0])
 
       ts_part = "#{timestamp.to_s}    "[0..(timestamp_width - 1)]
+      ts_part.prepend(pad) unless pad.nil?
       sj_part = truncate_str(subject, subject_width)
 
       ts_part + delimiter + sj_part
@@ -212,6 +215,7 @@ module Rbnotes
     ##
     # Finds all notes those timestamps match to given patterns in the
     # given repository.  Returns an Array contains Timestamp objects.
+    # The returned Array is sorted by Timestamp.
     #
     # :call-seq:
     #     find_notes(Array of timestamp patterns, Textrepo::Repository)


### PR DESCRIPTION
[issue #76]
- modify List#execute to accept "-v" (or "--verbose") option
- modify code around output for the list of notes
- modify Rbnotes::Utils::make_headline to accept a pad for the
  beginning of line

This PR will close #76.