### PR TITLE
feat: use template file for `add` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+- Add a feature to use a template file for `add` command. (#87)
 - Add new keywords for `list` command. (#90)
   - `this_month` and `last_month`
 - Add a new option, `verbose` for `list` command. (#76)

--- a/exe/rbnotes
+++ b/exe/rbnotes
@@ -64,6 +64,7 @@ rescue MissingArgumentError, MissingTimestampError,
        Textrepo::InvalidTimestampStringError,
        InvalidTimestampPatternError,
        NoConfFileError,
+       NoTemplateFileError,
        ArgumentError,
        Errno::EACCES => e
   puts e.message

--- a/lib/rbnotes/error.rb
+++ b/lib/rbnotes/error.rb
@@ -14,6 +14,7 @@ module Rbnotes
     UNKNOWN_KEYWORD   = "Unknown keyword: %s"
     INVALID_TIMESTAMP_PATTERN = "Invalid timestamp pattern: %s"
     NO_CONF_FILE      = "No configuration file: %s"
+    NO_TEMPLATE_FILE  = "No template file: %s"
   end
 
   # :startdoc:
@@ -92,6 +93,15 @@ module Rbnotes
   class NoArgumentError < Error
     def initialize
       super
+    end
+  end
+
+  ##
+  # An error raised when the specified template files does not exist.
+  #
+  class NoTemplateFileError < Error
+    def initialize(filepath)
+      super(ErrMsg::NO_TEMPLATE_FILE % filepath)
     end
   end
 

--- a/test/rbnotes_conf_test.rb
+++ b/test/rbnotes_conf_test.rb
@@ -96,6 +96,45 @@ class RbnotesConfTest < Minitest::Test
     }
   end
 
+  def test_it_holds_config_file_path
+    prepare_conf_file
+    conf = Rbnotes.conf(CONF_TEST_PATH)
+    assert_equal CONF_TEST_PATH, conf[:path]
+  end
+
+  def test_it_holds_config_home
+    conf = Rbnotes.conf
+    refute_nil conf[:config_home]
+  end
+
+  def test_it_holds_config_home_when_xdg_config_home_available
+    xdg_orig = ENV["XDG_CONFIG_HOME"]
+
+    prepare_xdg_conf
+    ENV["XDG_CONFIG_HOME"] = SANDBOX_DIR
+    conf = Rbnotes.conf
+
+    assert_equal File.join(ENV["XDG_CONFIG_HOME"], "rbnotes"), conf[:config_home]
+
+    ENV["XDG_CONFIG_HOME"] = xdg_orig if xdg_orig
+  end
+
+  def test_it_holds_config_home_when_xdg_config_home_unavailable
+    xdg_orig = ENV["XDG_CONFIG_HOME"]
+    home_orig = ENV["HOME"]
+
+    prepare_default_conf
+    ENV.delete("XDG_CONFIG_HOME")
+    ENV["HOME"] = SANDBOX_DIR
+    conf = Rbnotes::conf
+
+    expected = File.join(ENV["HOME"], ".config", "rbnotes")
+    assert_equal expected, conf[:config_home]
+
+    ENV["HOME"] = home_orig if home_orig
+    ENV["XDG_CONFIG_HOME"] = xdg_orig if xdg_orig
+  end
+
   private
   def prepare_conf_file
     conf_prod = CONF_BASE.dup

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,12 +8,14 @@ require "minitest/autorun"
 
 module RbnotesTestUtils
   CONF_RO = {
+    :config_home => File.expand_path("fixtures", __dir__),
     :repository_type => :file_system,
     :repository_name => "test_repo",
     :repository_base => File.expand_path("fixtures", __dir__),
   }
 
   CONF_RW = {
+    :config_home => File.expand_path("sandbox", __dir__),
     :repository_type => :file_system,
     :repository_name => "test_repo",
     :repository_base => File.expand_path("sandbox", __dir__),


### PR DESCRIPTION
[issue #87]
- add a new error to indicate the specified template file does not
  exist
- modify to catch NoTemplateFileError in the top level
- modify Add#execute;
  - to accept a new option "-f" (or "--template-file"),
  - to read a template file if it available
- refactor Rbnotes::Conf and modify to provide a value of
  `:config_home`
- add some test for the above modifications

This PR will close #87.