### PR TITLE
feat: enable to select multiple items for `pick`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+- Add a feature to refer the picker program option for `pick`
+  command. (#89)
 - Add a feature to use a template file for `add` command. (#87)
 - Add new keywords for `list` command. (#90)
   - `this_month` and `last_month`

--- a/conf/config.yml
+++ b/conf/config.yml
@@ -5,4 +5,5 @@
 :repository_base: "~"
 :pager: "bat -l md"
 :picker: "fzf"
+:picker_option: "-m"
 :editor: "/usr/local/bin/emacsclient"

--- a/conf/config_deve_fzf_no_opts.yml
+++ b/conf/config_deve_fzf_no_opts.yml
@@ -5,5 +5,4 @@
 :repository_base: "tmp"
 :pager: "bat -l md"
 :picker: "fzf"
-:picker_option: "-m"
 :editor: "/usr/local/bin/emacsclient"

--- a/conf/config_deve_no_picker.yml
+++ b/conf/config_deve_no_picker.yml
@@ -4,6 +4,4 @@
 :repository_name: "notes"
 :repository_base: "tmp"
 :pager: "bat -l md"
-:picker: "fzf"
-:picker_option: "-m"
 :editor: "/usr/local/bin/emacsclient"

--- a/conf/config_deve_peco.yml
+++ b/conf/config_deve_peco.yml
@@ -4,6 +4,5 @@
 :repository_name: "notes"
 :repository_base: "tmp"
 :pager: "bat -l md"
-:picker: "fzf"
-:picker_option: "-m"
+:picker: "peco"
 :editor: "/usr/local/bin/emacsclient"

--- a/lib/rbnotes/commands/pick.rb
+++ b/lib/rbnotes/commands/pick.rb
@@ -20,8 +20,12 @@ module Rbnotes::Commands
 
       picker = conf[:picker]
       unless picker.nil?
+        picker_opts = conf[:picker_option]
+        cmds = [picker]
+        cmds.concat(picker_opts.split) unless picker_opts.nil?
+
         require 'open3'
-        result = Open3.pipeline_rw(picker) { |stdin, stdout, _|
+        result = Open3.pipeline_rw(cmds) { |stdin, stdout, _|
           stdin.puts list
           stdin.close
           stdout.read


### PR DESCRIPTION
[issue #89]
- modify to refer config setting for the picker program options
- add picker options to some config file in the conf directory
- add some new config file to verify refering picker options

This PR will close #89.