### PR TITLE
fix: remove redundant args (Utils.read_multiple_timestamps)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+## [0.4.13] - 2021-03-30
+### Changed
 - Use GitHub/Actions instead of Travis-CI.
 - Add `--week` option to `pick` command. (#88)
+
+### Fixed
+- Fix issue #98: remove redundant args
+  (Rbnotes::Utils.read_multiple_timestamps). (#98)
+- Update `textrepo`. -> 0.5.8 (#97)
 
 ## [0.4.12] - 2020-12-18
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ gemspec
 gem "rake", "~> 13.0"
 gem "minitest", "~> 5.0"
 
-gem 'textrepo', "~> 0.5.4"
+gem 'textrepo', "~> 0.5.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    rbnotes (0.4.12)
-      textrepo (~> 0.5.4)
+    rbnotes (0.4.13)
+      textrepo (~> 0.5.8)
       unicode-display_width (~> 1.7)
 
 GEM
@@ -20,7 +20,7 @@ DEPENDENCIES
   minitest (~> 5.0)
   rake (~> 13.0)
   rbnotes!
-  textrepo (~> 0.5.4)
+  textrepo (~> 0.5.8)
 
 BUNDLED WITH
    2.2.3

--- a/lib/rbnotes.rb
+++ b/lib/rbnotes.rb
@@ -10,9 +10,4 @@ module Rbnotes
   require_relative "rbnotes/commands"
   require_relative "rbnotes/statistics"
 
-  class << self
-    def utils
-      Utils.instance
-    end
-  end
 end

--- a/lib/rbnotes/utils.rb
+++ b/lib/rbnotes/utils.rb
@@ -122,13 +122,20 @@ module Rbnotes
     # line arguments.  When no argument is given, try to read from
     # STDIN.
     #
+    # When multiple strings those point the identical time are
+    # included the arguments (passed or read form STDIN), the
+    # redundant strings will be removed.
+    #
+    # The order of the arguments will be preserved into the return
+    # value, even if the redundant strings were removed.
+    #
     # :call-seq:
     #   read_multiple_timestamps(args) -> [String]
 
     def read_multiple_timestamps(args)
       strings = args.size < 1 ? read_multiple_args($stdin) : args
       raise NoArgumentError if (strings.nil? || strings.empty?)
-      strings.map { |str| Textrepo::Timestamp.parse_s(str) }
+      strings.uniq.map { |str| Textrepo::Timestamp.parse_s(str) }
     end
 
     ##

--- a/lib/rbnotes/version.rb
+++ b/lib/rbnotes/version.rb
@@ -1,4 +1,4 @@
 module Rbnotes
-  VERSION = "0.4.12"
-  RELEASE = "2020-12-18"
+  VERSION = "0.4.13"
+  RELEASE = "2021-03-30"
 end

--- a/rbnotes.gemspec
+++ b/rbnotes.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "textrepo", "~> 0.5.4"
+  spec.add_dependency "textrepo", "~> 0.5.8"
   spec.add_dependency "unicode-display_width", "~> 1.7"
 end

--- a/test/rbnotes_utils_test.rb
+++ b/test/rbnotes_utils_test.rb
@@ -86,7 +86,7 @@ class RbnotesUtilsTest < Minitest::Test
   end
 
   # read_multiple_timestamps(args)
-  def test_read_multiple_timestamp_returns_an_array_of_timestamps
+  def test_read_multiple_timestamps_returns_an_array_of_timestamps
     timestamp0 = Textrepo::Timestamp.now
     stamp_args = [timestamp0, timestamp0.succ]
     args = stamp_args.map(&:to_s)
@@ -95,6 +95,22 @@ class RbnotesUtilsTest < Minitest::Test
     stamps = Rbnotes.utils.read_multiple_timestamps([])
 
     assert_equal stamp_args, stamps.sort
+  end
+
+  # for issue #98
+  def test_read_multiple_timestamps_removes_redundant_args
+    s0 = "2021-03-30_12:53:00"
+    s1 = "2020-01-01_11:22:33"
+    s2 = "2021-03-01_22:33:44"
+    args = [s0, s1, s0, s1, s2, s2].map{ |s| s.tr("-_:", "") }
+    stamps = Rbnotes.utils.read_multiple_timestamps(args)
+
+    assert_equal args.uniq.size, stamps.size
+
+    # check the order
+    assert_equal s0.tr("-_:", ""), stamps[0].to_s
+    assert_equal s1.tr("-_:", ""), stamps[1].to_s
+    assert_equal s2.tr("-_:", ""), stamps[2].to_s
   end
 
   # timestamps_in_week(timestamp)


### PR DESCRIPTION
[issue #98]
- modify to remove redundant args (lib/rbnotes/utils.rb)
- add test for issue #98 (test/rbnotes_utils_test.rb)
- remove an old redundant function (lib/rbnotes.rb)
  - fix a mistake to remove a garbage of refactoring (issue #88)
- update textrepo version (rbnotes.gemspec, Gemfile)
- update CHANGELOG.md
- bump version: 0.4.12 -> 0.4.13