### PR TITLE
fix: `show` command crashes with non-exisiting timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+- Fix issue #100: modify to catch Textrepo::MissingTimestampError.
 
 ## [0.4.13] - 2021-03-30
 ### Changed

--- a/test/rbnotes_commands_show_test.rb
+++ b/test/rbnotes_commands_show_test.rb
@@ -73,4 +73,12 @@ class RbnotesCommandsShowTest < Minitest::Test
     }
   end
 
+  # issue #100
+  def test_it_raises_missing_timestamp_when_valid_but_missing_timestamp_is_passed
+    arg = "2999-12-31_23:59:59".tr("-_:", "")
+    assert_raises(Rbnotes::MissingTimestampError) {
+      execute(:show, [arg], @conf_ro)
+    }
+  end
+
 end


### PR DESCRIPTION
[issue #100]
- modify to catch Textrepo::MissingTimestampError, then raise
  Rbnotes::MissingTimestampError which has been already caught at the
  toplevel
- add test to reproduce the symptom
- update CHANGELOG.md

This PR will close #100.