### PR TITLE
feat: accepts redundant delimiters in timestamp pattern or string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 - Nothing to record here.
 
+## [0.4.15] - 2021-04-15
+- Enable to use delimiters within a timestamp string. (#104)
+- Fix issue #105: `list` ignores the 2nd arg when specified `-w`
+  option.
+
 ## [0.4.14] - 2021-04-10
 - Add `-n` option to `show` command. (#102)
 - Fix issue #100: modify to catch Textrepo::MissingTimestampError.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rbnotes (0.4.14)
+    rbnotes (0.4.15)
       textrepo (~> 0.5.8)
       unicode-display_width (~> 1.7)
 

--- a/lib/rbnotes/commands/add.rb
+++ b/lib/rbnotes/commands/add.rb
@@ -34,22 +34,7 @@ module Rbnotes::Commands
 
     def execute(args, conf)
       @opts = {}
-      while args.size > 0
-        arg = args.shift
-        case arg
-        when "-t", "--timestamp"
-          stamp_str = args.shift
-          raise ArgumentError, "missing timestamp: %s" % args.unshift(arg) if stamp_str.nil?
-          stamp_str = complement_timestamp_pattern(stamp_str)
-          @opts[:timestamp] = Textrepo::Timestamp.parse_s(stamp_str)
-        when "-f", "--template-file"
-          template_path = args.shift
-          @opts[:template] = template_path
-        else
-          args.unshift(arg)
-          break
-        end
-      end
+      parse_opts(args)
 
       stamp = @opts[:timestamp] || Textrepo::Timestamp.new(Time.now)
 
@@ -116,7 +101,28 @@ HELP
     end
 
     # :stopdoc:
+
     private
+
+    def parse_opts(args)
+      while args.size > 0
+        arg = args.shift
+        case arg
+        when "-t", "--timestamp"
+          stamp_str = args.shift
+          raise ArgumentError, "missing timestamp: %s" % args.unshift(arg) if stamp_str.nil?
+          stamp_str = complement_timestamp_pattern(stamp_str)
+          @opts[:timestamp] = Textrepo::Timestamp.parse_s(stamp_str)
+        when "-f", "--template-file"
+          template_path = args.shift
+          @opts[:template] = template_path
+        else
+          args.unshift(arg)
+          break
+        end
+      end
+    end
+
     def complement_timestamp_pattern(pattern)
       stamp_str = nil
       case pattern.to_s.size

--- a/lib/rbnotes/commands/commands.rb
+++ b/lib/rbnotes/commands/commands.rb
@@ -12,18 +12,7 @@ module Rbnotes::Commands
 
     def execute(args, conf)
       @opts = {}
-      while args.size > 0
-        arg = args.shift
-        case arg.to_s
-        when ""                 # no options
-          break
-        when "-d", "--deve-commands"
-          @opts[:print_deve_commands] = true
-        else                    # invalid options or args
-          args.unshift(arg)
-          raise ArgumentError, "invalid option or argument: %s" % args.join(" ")
-        end
-      end
+      parse_opts(args)
 
       puts commands(@opts[:print_deve_commands]).join(" ")
     end
@@ -42,7 +31,23 @@ HELP
     end
 
     # :stopdoc:
+
     private
+
+    def parse_opts(args)
+      while args.size > 0
+        arg = args.shift
+        case arg.to_s
+        when ""                 # no options
+          break
+        when "-d", "--deve-commands"
+          @opts[:print_deve_commands] = true
+        else                    # invalid options or args
+          args.unshift(arg)
+          raise ArgumentError, "invalid option or argument: %s" % args.join(" ")
+        end
+      end
+    end
 
     ##
     # Enumerates all command names.

--- a/lib/rbnotes/commands/import.rb
+++ b/lib/rbnotes/commands/import.rb
@@ -29,16 +29,7 @@ module Rbnotes::Commands
 
     def execute(args, conf)
       @opts = {}
-      while args.size > 0
-        arg = args.shift
-        case arg
-        when "-m", "--use-mtime"
-          @opts[:use_mtime] = true
-        else
-          args.unshift(arg)
-          break
-        end
-      end
+      parse_opts(args)
 
       file = args.shift
       unless file.nil?
@@ -116,5 +107,25 @@ If birthtime is not available on the system, use mtime (modification
 time).
 HELP
     end
+
+    # :stopdoc:
+
+    private
+
+    def parse_opts(args)
+      while args.size > 0
+        arg = args.shift
+        case arg
+        when "-m", "--use-mtime"
+          @opts[:use_mtime] = true
+        else
+          args.unshift(arg)
+          break
+        end
+      end
+    end
+
+    # :startdoc:
+
   end
 end

--- a/lib/rbnotes/commands/list.rb
+++ b/lib/rbnotes/commands/list.rb
@@ -54,18 +54,7 @@ module Rbnotes::Commands
 
     def execute(args, conf)
       @opts = {}
-      while args.size > 0
-        arg = args.shift
-        case arg
-        when "-w", "--week"
-          @opts[:enum_week] = true
-        when "-v", "--verbose"
-          @opts[:verbose] = true
-        else
-          args.unshift(arg)
-          break
-        end
-      end
+      parse_opts(args)
 
       utils = Rbnotes.utils
       patterns = utils.read_timestamp_patterns(args, enum_week: @opts[:enum_week])
@@ -134,6 +123,21 @@ HELP
     # :stopdoc:
 
     private
+
+    def parse_opts(args)
+      while args.size > 0
+        arg = args.shift
+        case arg
+        when "-w", "--week"
+          @opts[:enum_week] = true
+        when "-v", "--verbose"
+          @opts[:verbose] = true
+        else
+          args.unshift(arg)
+          break
+        end
+      end
+    end
 
     def collect_timestamps_by_date(timestamps)
       result = {}

--- a/lib/rbnotes/commands/pick.rb
+++ b/lib/rbnotes/commands/pick.rb
@@ -11,16 +11,7 @@ module Rbnotes::Commands
 
     def execute(args, conf)
       @opts = {}
-      while args.size > 0
-        arg = args.shift
-        case arg
-        when "-w", "--week"
-          @opts[:enum_week] = true
-        else
-          args.unshift(arg)
-          break
-        end
-      end
+      parse_opts(args)
 
       utils = Rbnotes.utils
       patterns = utils.read_timestamp_patterns(args, enum_week: @opts[:enum_week])
@@ -61,5 +52,25 @@ is specified, it will behave as same as "list" command.
 
 HELP
     end
+
+    # :stopdoc:
+
+    private
+
+    def parse_opts(args)
+      while args.size > 0
+        arg = args.shift
+        case arg
+        when "-w", "--week"
+          @opts[:enum_week] = true
+        else
+          args.unshift(arg)
+          break
+        end
+      end
+    end
+
+    # :startdoc:
+
   end
 end

--- a/lib/rbnotes/commands/statistics.rb
+++ b/lib/rbnotes/commands/statistics.rb
@@ -9,20 +9,14 @@ module Rbnotes::Commands
     end
 
     def execute(args, conf)
+      @opts = {}
+      parse_opts(args)
+
       report = :total
-      while args.size > 0
-        arg = args.shift
-        case arg
-        when "-y", "--yearly"
-          report = :yearly
-          break
-        when "-m", "--monthly"
-          report = :monthly
-          break
-        else
-          args.unshift(arg)
-          raise ArgumentError, "invalid option or argument: %s" % args.join(" ")
-        end
+      if @opts[:yearly]
+        report = :yearly
+      elsif @opts[:monthly]
+        report = :monthly
       end
 
       stats = Rbnotes::Statistics.new(conf)
@@ -50,6 +44,31 @@ Show statistics.
 In the version #{Rbnotes::VERSION}, only number of notes is supported.
 HELP
     end
+
+    # :stopdoc:
+
+    private
+
+    def parse_opts(args)
+      while args.size > 0
+        arg = args.shift
+        case arg
+        when "-y", "--yearly"
+          @opts[:yearly] = true
+          @opts[:monthly] = false
+          break
+        when "-m", "--monthly"
+          @opts[:yearly] = false
+          @opts[:monthly] = true
+          break
+        else
+          args.unshift(arg)
+          raise ArgumentError, "invalid option or argument: %s" % args.join(" ")
+        end
+      end
+    end
+
+    # :startdoc:
 
   end
 end

--- a/lib/rbnotes/commands/update.rb
+++ b/lib/rbnotes/commands/update.rb
@@ -32,16 +32,7 @@ module Rbnotes::Commands
 
     def execute(args, conf)
       @opts = {}
-      while args.size > 0
-        arg = args.shift
-        case arg
-        when "-k", "--keep"
-          @opts[:keep_timestamp] = true
-        else
-          args.unshift(arg)
-          break
-        end
-      end
+      parse_opts(args)
 
       target_stamp = Rbnotes.utils.read_timestamp(args)
       editor = Rbnotes.utils.find_editor(conf[:editor])
@@ -100,5 +91,25 @@ editor program will be searched as same as add command.  If none of
 editors is available, the execution fails.
 HELP
     end
+
+    # :stopdoc:
+
+    private
+
+    def parse_opts(args)
+      while args.size > 0
+        arg = args.shift
+        case arg
+        when "-k", "--keep"
+          @opts[:keep_timestamp] = true
+        else
+          args.unshift(arg)
+          break
+        end
+      end
+    end
+
+    # :startdoc:
+
   end
 end

--- a/lib/rbnotes/version.rb
+++ b/lib/rbnotes/version.rb
@@ -1,4 +1,4 @@
 module Rbnotes
-  VERSION = "0.4.14"
-  RELEASE = "2021-04-10"
+  VERSION = "0.4.15"
+  RELEASE = "2021-04-15"
 end

--- a/test/rbnotes_utils_test.rb
+++ b/test/rbnotes_utils_test.rb
@@ -125,7 +125,7 @@ class RbnotesUtilsTest < Minitest::Test
       "2020-11-21",             # Sat
       "2020-11-22",             # Sun
     ].map { |d| d.tr("-", "") }
-    days = Rbnotes.utils.timestamp_patterns_in_week(a_day)
+    days = Rbnotes.utils.timestamp_patterns_in_week(a_day.to_s)
     refute days.nil?
     assert_equal 7, days.size
 


### PR DESCRIPTION
[issue #104]

- add code to remove redundant delimiters before to pass to
  `Textrepo::Timestamp.parse_s` (lib/rbnotes/utils.rb)
  - fix a test (test/rbnotes_utils_test.rb)
- refactor:
  - replace `some_array.sort.uniq` to `some_array.uniq.sort`
    - it might be save computing time
  - move code around "parsing options" to a private method
    - add.rb, commands.rb, import.rb, list.rb, pick.rb, statistics.rb,
      update.rb
    - in some future, it will be moved to Utils class or a new module
      or class.
- bump version: 0.4.14 -> 0.4.15

This PR will close #104.