### PR TITLE
feat: add a new conf setting to specify `list` default behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 - Nothing to record here.
 
+## [0.4.16] - 2021-04-17
+- Add a new configuration setting to change the default behavior of
+  the `list` (and `pick`) command. (#109)
+
 ## [0.4.15] - 2021-04-15
 - Enable to use delimiters within a timestamp string. (#104)
 - Fix issue #105: `list` ignores the 2nd arg when specified `-w`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rbnotes (0.4.15)
+    rbnotes (0.4.16)
       textrepo (~> 0.5.8)
       unicode-display_width (~> 1.7)
 

--- a/lib/rbnotes/commands/list.rb
+++ b/lib/rbnotes/commands/list.rb
@@ -10,6 +10,8 @@ module Rbnotes::Commands
       "List notes"
     end
 
+    DEFAULT_BEHAVIOR = "today"  # :nodoc:
+
     ##
     # Shows a list of notes in the repository.  Arguments are
     # optional.  If several args are passed, each of them must be a
@@ -56,6 +58,11 @@ module Rbnotes::Commands
       @opts = {}
       parse_opts(args)
 
+      if args.empty?
+        default_behavior = conf[:list_default] || DEFAULT_BEHAVIOR
+        args << default_behavior
+      end
+
       utils = Rbnotes.utils
       patterns = utils.read_timestamp_patterns(args, enum_week: @opts[:enum_week])
 
@@ -68,13 +75,13 @@ module Rbnotes::Commands
           timestamps.each { |timestamp|
             pad = "  "
             output << utils.make_headline(timestamp,
-                                                  @repo.read(timestamp), pad)
+                                          @repo.read(timestamp), pad)
           }
         }
       else
         notes.each { |timestamp|
           output << utils.make_headline(timestamp,
-                                                @repo.read(timestamp))
+                                        @repo.read(timestamp))
         }
       end
       puts output

--- a/lib/rbnotes/commands/pick.rb
+++ b/lib/rbnotes/commands/pick.rb
@@ -9,9 +9,16 @@ module Rbnotes::Commands
       "Pick a timestamp with a picker program"
     end
 
+    DEFAULT_BEHAVIOR = "today"  # :nodoc:
+
     def execute(args, conf)
       @opts = {}
       parse_opts(args)
+
+      if args.empty?
+        default_behavior = conf[:list_default] || DEFAULT_BEHAVIOR
+        args << default_behavior
+      end
 
       utils = Rbnotes.utils
       patterns = utils.read_timestamp_patterns(args, enum_week: @opts[:enum_week])

--- a/lib/rbnotes/utils.rb
+++ b/lib/rbnotes/utils.rb
@@ -247,17 +247,18 @@ module Rbnotes
     #   - "last_week"  (or "lw")
     #   - "this_month" (or "tm")
     #   - "last_month" (or "lm")
+    #   - "all"
     #
     # :call-seq:
     #   expand_keyword_in_args(Array of Strings) -> Array of Strings
     #
     def expand_keyword_in_args(args)
-      return [nil] if args.empty?
-
       patterns = []
       while args.size > 0
         arg = args.shift
-        if KEYWORDS.include?(arg)
+        if arg == "all"
+          return [nil]
+        elsif KEYWORDS.include?(arg)
           patterns.concat(expand_keyword(arg))
         else
           patterns << arg

--- a/lib/rbnotes/version.rb
+++ b/lib/rbnotes/version.rb
@@ -1,4 +1,4 @@
 module Rbnotes
-  VERSION = "0.4.15"
-  RELEASE = "2021-04-15"
+  VERSION = "0.4.16"
+  RELEASE = "2021-04-17"
 end

--- a/test/rbnotes_commands_list_test.rb
+++ b/test/rbnotes_commands_list_test.rb
@@ -10,10 +10,10 @@ class RbnotesCommandsListTest < Minitest::Test
     @conf_rw[:repository_name] = "repo_list_test"
   end
 
-  def test_that_it_can_list_up_all_notes
+  def test_that_it_can_list_up_all_notes_using_all_kw
     files = Dir.glob("#{repo_path(CONF_RO)}/**/*.md").map{|f| File.basename(f)}
 
-    result = execute(:list, [], CONF_RO)
+    result = execute(:list, ["all"], CONF_RO)
 
     refute result.empty?
     result.lines.each { |line|
@@ -184,6 +184,22 @@ class RbnotesCommandsListTest < Minitest::Test
     assert_equal 14, result.lines.size
   end
 
+  # [issue #109]
+  def test_it_change_its_default_behavoir_with_list_default_setting
+    conf = @conf_rw.dup
+    conf[:repository_name] = "repo_list_default_setting"
+    conf[:list_default] = "ye"
+
+    str = Time.now.to_s
+
+    prepare_today_note([str], conf)
+    prepare_yesterday_note(["Yesterday"], conf)
+
+    result = execute(:list, [], conf)
+    assert result.include?("Yesterday")
+    refute result.include?(str)
+  end
+
   private
 
   def extract_subject(file)
@@ -197,16 +213,16 @@ class RbnotesCommandsListTest < Minitest::Test
     assert_equal files.size, result.lines.size
   end
 
-  def prepare_today_note(text)
+  def prepare_today_note(text, conf = @conf_rw)
     today = Textrepo::Timestamp.new(Time.now).to_s
-    prepare_note(today, text, repo_path(@conf_rw))
+    prepare_note(today, text, repo_path(conf))
   end
 
   require "date"
 
-  def prepare_yesterday_note(text)
+  def prepare_yesterday_note(text, conf = @conf_rw)
     ye_pattern = "#{yesterday_stamp_pattern}010203"
-    prepare_note(ye_pattern, text, repo_path(@conf_rw))
+    prepare_note(ye_pattern, text, repo_path(conf))
   end
 
   def prepare_this_week_notes(text, conf = @conf_rw)

--- a/test/rbnotes_commands_pick_test.rb
+++ b/test/rbnotes_commands_pick_test.rb
@@ -9,7 +9,7 @@ class RbnotesCommandsPickTest < Minitest::Test
   end
 
   def test_it_can_pick_one_item
-    result = execute(:pick, [], @conf)
+    result = execute(:pick, ["all"], @conf)
     refute result.empty?
     assert_equal 1, result.split("\n").size
     assert_match %r([0-9]{14}), result[0, 14]
@@ -17,7 +17,7 @@ class RbnotesCommandsPickTest < Minitest::Test
 
   def test_it_just_print_list_when_no_picker_set
     @conf.delete(:picker)
-    result = execute(:pick, [], @conf)
+    result = execute(:pick, ["all"], @conf)
     refute result.empty?
     assert_operator 1, :<=, result.split("\n").size
     assert_match %r([0-9]{14}), result[0, 14]


### PR DESCRIPTION
[issue #109]
- change the default behavior of `list` and `pick`
  - if no args, enumerates "today" notes
  - if conf setting, "list_default" is specified, use the value
    as the default behavior
- add a keyword, "all" to `list` and `pick`
  - to specify enumerate all notes in the repo
- bump version: 0.4.15 -> 0.4.16

This PR will close #109.