### PR TITLE
feat: `show` command accepts keywords like `list` (#84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,42 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+- nothing to record here.
+
+## [0.4.17] - 2021-04-21
+### Added
+- Change for the `show` command to accept keywords. (#84)
+- Add `-r` option to the `show` command. (#110)
+  - which specifies to enable "raw" output mode.
+
+### Fixed
 - Update the help text for the `list` command. (#112, #113)
 - Remove trailing spaces. (#108)
+- Fix minor bugs:
+  - remove redundant use of an instance variable,
+  - change the behavior to exit when no notes found in the repo,
+    - `pick` and `show`
+  - change delimiter line size according to terminal column.
+    - `show`
 
 ## [0.4.16] - 2021-04-17
+### Added
 - Add a new configuration setting to change the default behavior of
   the `list` (and `pick`) command. (#109)
 
 ## [0.4.15] - 2021-04-15
+### Added
 - Enable to use delimiters within a timestamp string. (#104)
+
+### Fixed
 - Fix issue #105: `list` ignores the 2nd arg when specified `-w`
   option.
 
 ## [0.4.14] - 2021-04-10
+### Added
 - Add `-n` option to `show` command. (#102)
+
+### Fixed
 - Fix issue #100: modify to catch Textrepo::MissingTimestampError.
 
 ## [0.4.13] - 2021-03-30

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rbnotes (0.4.16)
+    rbnotes (0.4.17)
       textrepo (~> 0.5.8)
       unicode-display_width (~> 1.7)
 

--- a/lib/rbnotes/commands/list.rb
+++ b/lib/rbnotes/commands/list.rb
@@ -18,7 +18,8 @@ module Rbnotes::Commands
     # timestamp pattern or a keyword.
     #
     # Any order of timestamp patterns and keywords mixture is
-    # acceptable.  The redundant patterns are just ignored.
+    # acceptable.  The redundant patterns or invalid patterns are just
+    # ignored.
     #
     # A timestamp pattern is a string which would match several
     # Timestamp objects.  A timestamp is an instance of
@@ -66,22 +67,21 @@ module Rbnotes::Commands
       utils = Rbnotes.utils
       patterns = utils.read_timestamp_patterns(args, enum_week: @opts[:enum_week])
 
-      @repo = Textrepo.init(conf)
-      notes = utils.find_notes(patterns, @repo)
+      repo = Textrepo.init(conf)
+      stamps = utils.find_notes(patterns, repo)
       output = []
       if @opts[:verbose]
-        collect_timestamps_by_date(notes).each { |date, timestamps|
+        collect_timestamps_by_date(stamps).each { |date, timestamps|
           output << "#{date} (#{timestamps.size})"
           timestamps.each { |timestamp|
             pad = "  "
             output << utils.make_headline(timestamp,
-                                          @repo.read(timestamp), pad)
+                                          repo.read(timestamp), pad)
           }
         }
       else
-        notes.each { |timestamp|
-          output << utils.make_headline(timestamp,
-                                        @repo.read(timestamp))
+        stamps.each { |timestamp|
+          output << utils.make_headline(timestamp, repo.read(timestamp))
         }
       end
       puts output

--- a/lib/rbnotes/commands/pick.rb
+++ b/lib/rbnotes/commands/pick.rb
@@ -23,11 +23,14 @@ module Rbnotes::Commands
       utils = Rbnotes.utils
       patterns = utils.read_timestamp_patterns(args, enum_week: @opts[:enum_week])
 
-      @repo = Textrepo.init(conf)
+      repo = Textrepo.init(conf)
+
+      stamps = utils.find_notes(patterns, repo)
+      return if stamps.empty?
 
       list = []
-      utils.find_notes(patterns, @repo).each { |timestamp|
-        list << utils.make_headline(timestamp, @repo.read(timestamp))
+      stamps.each { |timestamp|
+        list << utils.make_headline(timestamp, repo.read(timestamp))
       }
 
       picker = conf[:picker]

--- a/lib/rbnotes/version.rb
+++ b/lib/rbnotes/version.rb
@@ -1,4 +1,4 @@
 module Rbnotes
-  VERSION = "0.4.16"
-  RELEASE = "2021-04-17"
+  VERSION = "0.4.17"
+  RELEASE = "2021-04-21"
 end

--- a/test/rbnotes_commands_show_test.rb
+++ b/test/rbnotes_commands_show_test.rb
@@ -10,7 +10,7 @@ class RbnotesCommandsShowTest < Minitest::Test
 
   def test_that_it_can_show_the_specified_note
     files = [
-      "20201012005000.md",
+      "20200912005000_089.md",
       "20201012005000_089.md",
     ]
     cmd = load_cmd(:show)
@@ -26,7 +26,7 @@ class RbnotesCommandsShowTest < Minitest::Test
   end
 
   def test_that_it_reads_arg_from_stdin_when_no_args
-    timestamp_str = "20201012005001"
+    timestamp_str = "20201012005001_089"
     file = timestamp_to_path(timestamp_str, repo_path(@conf_ro))
 
     cmd = load_cmd(:show)
@@ -77,7 +77,9 @@ class RbnotesCommandsShowTest < Minitest::Test
   def test_it_raises_missing_timestamp_when_valid_but_missing_timestamp_is_passed
     arg = "2999-12-31_23:59:59".tr("-_:", "")
     assert_raises(Rbnotes::MissingTimestampError) {
-      execute(:show, [arg], @conf_ro)
+      $stdin = StringIO.new(arg)
+      execute(:show, [], @conf_ro)
+      $stdin = STDOUT
     }
   end
 


### PR DESCRIPTION
[issue #84, #110]
- change for `show` to accept keywords (#84)
- add "-r" ("--raw") option to `show` (#110)
- update the help text of `show` (#84, #110)
- fix minor bugs:
  - remove redundant use of an instance variable
    - lib/rbnotes/commands/list.rb
    - lib/rbnotes/commands/pick.rb
  - change the behavior to exit when no notes found in the repo
    - `pick` and `show`
  - change delimiter line size according to terminal column
    - `show`
- fix tests for `show` to suit this update
- bump version: 0.4.16 -> 0.4.17

This PR will:
- close #84,
- close #110.