### PR TITLE
feat: add an option to search in only the subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 - (nothing to record here)
 
+## [0.4.19] - 2021-05-24
+### Added
+- Add an option to search in only the subject of each note. (#128)
+
+### Modified
+- Update copyright year in `LICENSE`. (#127)
+
+### Fixed
+- Fix #129: add description about the keyword, "all."
+
 ## [0.4.18] - 2021-04-29
 ### Added
 - Use ERB to generate the initial content of a new note from the

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rbnotes (0.4.18)
+    rbnotes (0.4.19)
       textrepo (~> 0.5.8)
       unicode-display_width (~> 1.7)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 mnbi
+Copyright (c) 2020, 2021 mnbi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/rbnotes/commands/list.rb
+++ b/lib/rbnotes/commands/list.rb
@@ -33,6 +33,7 @@ module Rbnotes::Commands
     #   - "last_week"  (or "lw")
     #   - "this_month" (or "tm")
     #   - "last_month" (or "lm")
+    #   - "all"
     #
     # Here is several examples of timestamp patterns.
     #
@@ -106,23 +107,6 @@ OPTIONS:
     -v, --verbose
     -w, --week
 
-STAMP_PATTERN must be:
-
-    (a) full qualified timestamp (with suffix): "20201030160200"
-    (b) year and date part: "20201030"
-    (c) year and month part: "202010"
-    (d) year part only: "2020"
-    (e) date part only: "1030"
-
-KEYWORD:
-
-    - "today"      (or "to")
-    - "yeasterday" (or "ye")
-    - "this_week"  (or "tw")
-    - "last_week"  (or "lw")
-    - "this_month" (or "tm")
-    - "last_month" (or "lm")
-
 An option "--verbose" is acceptable.  It specifies to counts number of
 notes by each day, then put it with the date before notes.  It looks
 like as follows:
@@ -140,11 +124,32 @@ days of a week.  Typically, the option is used with a STAMP_PATTERN
 which specifies a date, such "20201117", then it enumerates all days
 of the week which contains "17th November 2020".
 
+STAMP_PATTERN must be:
+
+    (a) full qualified timestamp (with suffix): "20201030160200"
+    (b) year and date part: "20201030"
+    (c) year and month part: "202010"
+    (d) year part only: "2020"
+    (e) date part only: "1030"
+
 A STAMP_PATTERN other than (a) and (b) causes an error if it was used
 with "--week" option.
 
 When no STAMP_PATTERN was specified with "--week" option, the output
 would be as same as the KEYWORD, "this_week" was specified.
+
+KEYWORD:
+
+    - "today"      (or "to")
+    - "yeasterday" (or "ye")
+    - "this_week"  (or "tw")
+    - "last_week"  (or "lw")
+    - "this_month" (or "tm")
+    - "last_month" (or "lm")
+    - "all"
+
+The keyword, "all" specifies to enumerate all notes in the repository.
+
 HELP
     end
 

--- a/lib/rbnotes/version.rb
+++ b/lib/rbnotes/version.rb
@@ -1,4 +1,4 @@
 module Rbnotes
-  VERSION = "0.4.18"
-  RELEASE = "2021-04-29"
+  VERSION = "0.4.19"
+  RELEASE = "2021-05-24"
 end


### PR DESCRIPTION
[issue #127, #128, #129]
- modify to accept the option, "--subject-only" in `search` (#128)
- add description about the keyword, "all" in the help text of `list`
  (#129)
- add an update year into LICENSE (#127)
- bump version: 0.4.18 -> 0.4.19

This PR will:
- close #128,
- fix #127,
- fix #129.