### PR TITLE
feat: add a new keyword to enumerate recent notes. (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 - (nothing to record here)
 
+## [0.4.20] - 2022-12-03
+### Added
+- Add a new keyword, `recent`. (#131)
+
 ## [0.4.19] - 2021-05-24
 ### Added
 - Add an option to search in only the subject of each note. (#128)

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ gemspec
 gem "rake", "~> 13.0"
 gem "minitest", "~> 5.0"
 
-gem 'textrepo', "~> 0.5.8"
+gem 'textrepo', "~> 0.5.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,26 @@
 PATH
   remote: .
   specs:
-    rbnotes (0.4.19)
-      textrepo (~> 0.5.8)
-      unicode-display_width (~> 1.7)
+    rbnotes (0.4.20)
+      textrepo (~> 0.5.9)
+      unicode-display_width (~> 1.8)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    minitest (5.14.4)
-    rake (13.0.3)
-    textrepo (0.5.8)
-    unicode-display_width (1.7.0)
+    minitest (5.16.3)
+    rake (13.0.6)
+    textrepo (0.5.9)
+    unicode-display_width (1.8.0)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-22
 
 DEPENDENCIES
   minitest (~> 5.0)
   rake (~> 13.0)
   rbnotes!
-  textrepo (~> 0.5.8)
+  textrepo (~> 0.5.9)
 
 BUNDLED WITH
-   2.2.15
+   2.3.11

--- a/exe/rbnotes
+++ b/exe/rbnotes
@@ -66,6 +66,7 @@ rescue MissingArgumentError, MissingTimestampError,
        InvalidTimestampPatternAsDateError,
        NoConfFileError,
        NoTemplateFileError,
+       UnknownKeywordError,
        ArgumentError,
        Errno::EACCES => e
   puts e.message

--- a/lib/rbnotes/commands/export.rb
+++ b/lib/rbnotes/commands/export.rb
@@ -22,6 +22,7 @@ module Rbnotes::Commands
 
     def execute(args, conf)
       stamp = Rbnotes.utils.read_timestamp(args)
+      args.shift                # drop the 1st argument
 
       repo = Textrepo.init(conf)
       begin

--- a/lib/rbnotes/commands/list.rb
+++ b/lib/rbnotes/commands/list.rb
@@ -33,6 +33,7 @@ module Rbnotes::Commands
     #   - "last_week"  (or "lw")
     #   - "this_month" (or "tm")
     #   - "last_month" (or "lm")
+    #   - "recent"     (or "re")
     #   - "all"
     #
     # Here is several examples of timestamp patterns.
@@ -67,9 +68,11 @@ module Rbnotes::Commands
 
       utils = Rbnotes.utils
       patterns = utils.read_timestamp_patterns(args, enum_week: @opts[:enum_week])
-
       repo = Textrepo.init(conf)
-      stamps = utils.find_notes(patterns, repo)
+
+      num_of_notes = utils.specified_recent?(args) ? conf[:number_of_recent_notes] : 0
+      stamps = utils.find_notes(patterns, repo, num_of_notes)
+
       output = []
       if @opts[:verbose]
         collect_timestamps_by_date(stamps).each { |date, timestamps|
@@ -146,9 +149,12 @@ KEYWORD:
     - "last_week"  (or "lw")
     - "this_month" (or "tm")
     - "last_month" (or "lm")
+    - "recent"     (or "re")
     - "all"
 
-The keyword, "all" specifies to enumerate all notes in the repository.
+The keyword, "recent" specifies to enumerate recent notes in the
+repository.  The keyword, "all" specifies to enumerate all notes in
+the repository.
 
 HELP
     end

--- a/lib/rbnotes/commands/pick.rb
+++ b/lib/rbnotes/commands/pick.rb
@@ -25,7 +25,8 @@ module Rbnotes::Commands
 
       repo = Textrepo.init(conf)
 
-      stamps = utils.find_notes(patterns, repo)
+      num_of_notes = utils.specified_recent?(args) ? conf[:number_of_recent_notes] : 0
+      stamps = utils.find_notes(patterns, repo, num_of_notes)
       return if stamps.empty?
 
       list = []

--- a/lib/rbnotes/commands/show.rb
+++ b/lib/rbnotes/commands/show.rb
@@ -22,7 +22,7 @@ module Rbnotes::Commands
       parse_opts(args)
 
       repo = Textrepo.init(conf)
-      stamps = read_timestamps(args, repo)
+      stamps = read_timestamps(args, repo, conf)
       return if stamps.empty?
 
       content = stamps.map { |stamp|
@@ -98,13 +98,14 @@ HELP
       end
     end
 
-    def read_timestamps(args, repo)
+    def read_timestamps(args, repo, conf)
       utils = Rbnotes.utils
       if args.empty?
         stamps = utils.read_multiple_timestamps(args)
       else
         patterns = utils.read_timestamp_patterns(args)
-        stamps = utils.find_notes(patterns, repo)
+        num_of_notes = utils.specified_recent?(args) ? conf[:number_of_recent_notes] : 0
+        stamps = utils.find_notes(patterns, repo, num_of_notes)
       end
       stamps
     end

--- a/lib/rbnotes/conf.rb
+++ b/lib/rbnotes/conf.rb
@@ -31,6 +31,12 @@ module Rbnotes
 
     DIRNAME_COMMON_CONF = ".config"
 
+    ##
+    # Name of the number of notes to enumerate.  The values is
+    # referred only to enumerate the recent notes.
+
+    NUMBER_OF_RECENT_NOTES = 10
+
     def initialize(path = nil)   # :nodoc:
       @conf = {}
 
@@ -90,6 +96,7 @@ module Rbnotes
       :repository_type => :file_system,
       :repository_name => "notes",
       :repository_base => "~",
+      :number_of_recent_notes => 10,
     }
 
     MODE_POSTFIX = {

--- a/lib/rbnotes/version.rb
+++ b/lib/rbnotes/version.rb
@@ -1,4 +1,4 @@
 module Rbnotes
-  VERSION = "0.4.19"
-  RELEASE = "2021-05-24"
+  VERSION = "0.4.20"
+  RELEASE = "2022-12-03"
 end

--- a/rbnotes.gemspec
+++ b/rbnotes.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "textrepo", "~> 0.5.8"
-  spec.add_dependency "unicode-display_width", "~> 1.7"
+  spec.add_dependency "textrepo", "~> 0.5.9"
+  spec.add_dependency "unicode-display_width", "~> 1.8"
 end


### PR DESCRIPTION
[issue #131]
- modify to accept a new keyword:
  - change the signature of Rbnotes::Utils.find_notes to accept the 2nd argument (default value: 0), which specifies how many notes to enumerate.
  - fix bugs around missing duplication of command arguments.
  - modify 3 commands ("list", "pick", and "show") to check the command arguments whether "recent" is specified or not.
  - add description about the "recent" keyword to help text of the "list" command.
- also fix a bug around missing duplication of command arguments.
- bump version: 0.4.19 -> 0.4.20