### PR TITLE
change to cope with the deprecation of Node.js 12 for Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,13 +6,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1.0
+        ruby-version: 3.1.3
     - name: Run the default task
       run: |
-        gem install bundler -v 2.2.3
+        gem install bundler -v 2.3.26
         bundle install
         bundle exec rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,4 +23,4 @@ DEPENDENCIES
   textrepo (~> 0.5.9)
 
 BUNDLED WITH
-   2.3.11
+   2.3.26


### PR DESCRIPTION
- change `checkout` version,
- change `ruby-version`: 3.1.0 -> 3.1.3,
- change `bundler` version: 2.2.3 -> 2.3.26 (ship with ruby 3.1.3).